### PR TITLE
🔧 feat: add INSTALL_DEV build argument to Docker image build process

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build & tag Docker image
         run: |
-          docker build \
+          docker build --build-arg INSTALL_DEV=true \
             -t ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.branch }} \
             -t ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha }} \
             -f Dockerfile .


### PR DESCRIPTION
This pull request modifies the Docker build process in the GitHub Actions workflow to support development-specific configurations.

* [`.github/workflows/docker-compose-develop.yml`](diffhunk://#diff-df0350229a00b492c0728b7dd254cd53fe8d1ee6dbe591553a8cc0aa090747e8L35-R35): Added the `--build-arg INSTALL_DEV=true` argument to the `docker build` command to enable installation of development dependencies during the image build process.