### PR TITLE
🔧 feat: update Dockerfile to use Debian-based Node image and improve …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 # 🏗️ Build stage
-FROM node:22-alpine AS builder
+FROM node:22 AS builder
 
 WORKDIR /app
 
-RUN apk add --no-cache \
-  python3 \
-  make \
-  g++ \
-  libc6-compat \
-  libstdc++ \
-  sqlite-dev
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    libc6 \
+    libstdc++6 \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY package.json package-lock.json ./
 
@@ -28,7 +29,7 @@ RUN npm run build
 
 
 # 🚀 Final stage
-FROM node:22-alpine
+FROM node:22
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve compatibility and streamline the build process. The changes primarily involve switching the base image from `node:22-alpine` to `node:22` and replacing the package manager from `apk` to `apt-get`.

### Changes to improve compatibility:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R13): Changed the base image from `node:22-alpine` to `node:22` to ensure compatibility with certain dependencies and libraries. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R13) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L31-R32)

### Changes to streamline the build process:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R13): Replaced `apk` with `apt-get` for installing dependencies, which includes `python3`, `make`, `g++`, `libc6`, `libstdc++6`, and `libsqlite3-dev`. Added cleanup commands to remove cached files after installation.…package installation