### PR TITLE
🔧 feat: add NODE_ENV argument to Dockerfile and enable experimental d…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # 🏗️ Build stage
 FROM node:22 AS builder
 
+# Usa NODE_ENV para determinar si es dev o prod
+ARG NODE_ENV=development
+ENV NODE_ENV=${NODE_ENV}
+
 WORKDIR /app
 
 # Herramientas necesarias para compilar bindings nativos

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,9 @@ const isDev = process.env.NODE_ENV !== 'production'
 export default defineNuxtConfig({
   compatibilityDate: "2025-05-15",
   devtools: { enabled: isDev },
+  experimental: {
+    devTools: isDev
+  },
   sourcemap: {
     server: isDev,
     client: isDev


### PR DESCRIPTION
This pull request introduces changes to better handle development and production environments by incorporating the `NODE_ENV` variable into the Dockerfile and updating the Nuxt configuration to use this variable dynamically.

Environment setup improvements:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R4-R7): Added an `ARG NODE_ENV` and set the `NODE_ENV` environment variable to dynamically determine if the environment is development or production.

Nuxt configuration enhancements:

* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R8-R10): Updated the configuration to use `process.env.NODE_ENV` for enabling experimental features and sourcemaps based on whether the environment is development (`isDev`).…evTools in nuxt.config.ts