### PR TITLE
Add CI/CD linting step for Nuxt frontend in docker-compose

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -1,15 +1,41 @@
-name: CI/CD - Build & Deploy SIGIC Keycloak (develop)
+name: CI & CD - Lint, Build & Deploy SIGIC Nuxt Frontend (develop)
 
 on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 jobs:
+  lint:
+    name: Lint Nuxt frontend code
+    runs-on: ubuntu-latest
+    environment: develop
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+
   build:
     name: Build SIGIC Nuxt Frontend image (develop)
+    needs: lint
     runs-on: [self-hosted, build-develop, sigic-nuxt-frontend]
     environment: develop
+    if: github.event_name == 'push'
 
     permissions:
       packages: write
@@ -42,11 +68,14 @@ jobs:
           docker push ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.branch }}
           docker push ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha }}
 
+
+
   deploy:
     name: Deploy SIGIC Nuxt frontend to dev server
     needs: build
     runs-on: [self-hosted, deploy-develop, sigic-nuxt-frontend]
     environment: develop
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout repo
@@ -81,3 +110,7 @@ jobs:
           KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
           NUXT_AUTH_SECRET: ${{ secrets.NUXT_AUTH_SECRET }}
           VIRTUAL_PORT: "3000"
+
+      - name: Clean old Docker images
+        run: |
+          docker image prune -f


### PR DESCRIPTION
# Actualización del workflow de CI/CD para el frontend Nuxt de SIGIC

Este pull request actualiza el flujo de trabajo de CI/CD del proyecto frontend Nuxt de SIGIC para incluir un paso de linting, mejorar el manejo de ramas y optimizar la gestión de imágenes Docker. A continuación se detallan los cambios más importantes:

### Mejoras en el Workflow

- Se renombró el workflow para reflejar su enfoque en el frontend Nuxt de SIGIC y se agregó soporte para eventos de `pull_request` en la rama `develop`. (`.github/workflows/docker-compose-develop.yml`)
- Se introdujo un nuevo job llamado `lint` para verificar el código del frontend Nuxt usando ESLint antes del build. Este job se ejecuta en `ubuntu-latest` y es requerido antes del job `build`. (`.github/workflows/docker-compose-develop.yml`)

### Ejecución Condicional de Jobs

- Se actualizaron los jobs `build` y `deploy` para que se ejecuten únicamente en eventos de `push`, permitiendo un mejor control sobre cuándo se disparan estos pasos. (`.github/workflows/docker-compose-develop.yml`)

### Gestión de Imágenes Docker

- Se añadió un paso para limpiar imágenes Docker antiguas usando `docker image prune -f` después de definir las variables de entorno, ayudando así a gestionar el espacio en disco en los servidores de build. (`.github/workflows/docker-compose-develop.yml`)
