### PR TITLE
Refactor GitHub Actions workflow by removing unnecessary dependency o…

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -31,10 +31,8 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
-
   build:
     name: Build SIGIC Nuxt Frontend image (develop)
-    needs: lint
     runs-on: [self-hosted, build-develop, sigic-nuxt-frontend]
     environment: develop
     if: github.event_name == 'push'


### PR DESCRIPTION
This pull request makes a small adjustment to the `.github/workflows/docker-compose-develop.yml` file by removing the dependency between the `build` job and the `lint` job. This change ensures that the `build` job no longer waits for the `lint` job to complete before running.…n linting for the build step