### PR TITLE
GitHub actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ ENV NODE_ENV=${NODE_ENV:-development}
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    && rm -rf /var/lib/apt/lists/*
+RUN if [ "$NODE_ENV" = "development" ]; then \
+      apt-get update && apt-get install -y --no-install-recommends git \
+      && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/.output/ .output/
 COPY --from=builder /app/package.json .


### PR DESCRIPTION
This pull request introduces a conditional installation of `git` in the `Dockerfile` specifically for the development environment. This change ensures that `git` is only installed when `NODE_ENV` is set to `development`, optimizing the container for production by avoiding unnecessary packages.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R39-R42): Added a conditional block to install `git` only if `NODE_ENV` is set to `development`. This includes updating the package list, installing `git` with no recommended extras, and cleaning up the package cache to reduce image size.