### PR TITLE
Fix formatting in Dockerfile for development git installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,9 @@ ENV NODE_ENV=${NODE_ENV:-development}
 WORKDIR /app
 
 RUN if [ "$NODE_ENV" = "development" ]; then \
-      apt-get update && apt-get install -y --no-install-recommends git \
-      && rm -rf /var/lib/apt/lists/* \
+      apt-get update && \
+      apt-get install -y --no-install-recommends git && \
+      rm -rf /var/lib/apt/lists/*; \
     fi
 
 COPY --from=builder /app/.output/ .output/


### PR DESCRIPTION
This pull request includes a minor improvement to the `Dockerfile` for better readability and consistency in the `RUN` command structure.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L40-R42): Reformatted the `RUN` command to use consistent line breaks and trailing backslashes for improved readability and maintainability in the development environment setup.