### PR TITLE
Update auth baseURL to use environment variable for better configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,7 +43,7 @@ export default defineNuxtConfig({
 
   auth: {
     isEnabled: true,
-    baseURL: 'http://localhost:3000/api/auth',
+    baseURL: `${process.env.NUXT_PUBLIC_BASE_URL}/api/auth`,
     originEnvKey: process.env.NUXT_AUTH_ORIGIN,
 
     globalAppMiddleware: false, // protege todas las páginas por defecto


### PR DESCRIPTION
This pull request updates the authentication configuration in the Nuxt app to improve flexibility when deploying to different environments.

Configuration improvements:

* Changed the `auth.baseURL` in `nuxt.config.ts` to use the `NUXT_PUBLIC_BASE_URL` environment variable, making the authentication endpoint configurable per environment instead of hardcoded to localhost.