### PR TITLE
fix: update auth baseURL to use NUXT_AUTH_ORIGIN for improved configu…

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,7 +43,7 @@ export default defineNuxtConfig({
 
   auth: {
     isEnabled: true,
-    baseURL: `${process.env.NUXT_PUBLIC_BASE_URL}/api/auth`,
+    baseURL: `${process.env.NUXT_AUTH_ORIGIN}/api/auth`,
     originEnvKey: process.env.NUXT_AUTH_ORIGIN,
 
     globalAppMiddleware: false, // protege todas las páginas por defecto


### PR DESCRIPTION
This pull request makes a configuration update to the authentication settings in the `nuxt.config.ts` file. The change ensures that the base URL for authentication is now derived from the `NUXT_AUTH_ORIGIN` environment variable instead of `NUXT_PUBLIC_BASE_URL`, improving clarity and separation of environment configuration.

- Configuration update:
  * Changed the `auth.baseURL` to use the `NUXT_AUTH_ORIGIN` environment variable, making authentication origin configuration more explicit and consistent.