### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -61,8 +61,10 @@ jobs:
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             echo "NODE_ENV=production" >> "$GITHUB_OUTPUT"
+            echo "NUXT_PUBLIC_BASE_URL=https://sigic.geoint.mx" >> "$GITHUB_OUTPUT"
           else
             echo "NODE_ENV=development" >> "$GITHUB_OUTPUT"
+            echo "NUXT_PUBLIC_BASE_URL=https://sigic.dev.geoint.mx" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build & tag Docker image


### PR DESCRIPTION
This pull request updates the environment variable used for the Nuxt.js application's base URL throughout the `docker-compose-develop.yml` GitHub Actions workflow. The variable `NUXT_AUTH_BASE_URL` is replaced with `NUXT_PUBLIC_BASE_URL` to align with updated naming conventions or application requirements.

Configuration updates:

* Replaced the `NUXT_AUTH_BASE_URL` build argument with `NUXT_PUBLIC_BASE_URL` in the Docker build step (`.github/workflows/docker-compose-develop.yml`).
* Updated the `.env` file generation step to use `NUXT_PUBLIC_BASE_URL` instead of `NUXT_AUTH_BASE_URL` (`.github/workflows/docker-compose-develop.yml`).
* Changed the environment variable passed to the job from `NUXT_AUTH_BASE_URL` to `NUXT_PUBLIC_BASE_URL` (`.github/workflows/docker-compose-develop.yml`).