### PR TITLE
Update Dockerfile to replace NUXT_AUTH_BASE_URL with NUXT_PUBLIC_BASE…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM node:22 AS builder
 
 # Usa NODE_ENV para determinar si es dev o prod
 ARG NODE_ENV
-ARG NUXT_AUTH_BASE_URL
+ARG NUXT_PUBLIC_BASE_URL
 ENV NODE_ENV=${NODE_ENV:-development}
-ENV NUXT_AUTH_BASE_URL=${NUXT_AUTH_BASE_URL:-http://localhost:3000}
+ENV NUXT_PUBLIC_BASE_URL=${NUXT_PUBLIC_BASE_URL:-http://localhost:3000}
 
 WORKDIR /app
 
@@ -34,6 +34,8 @@ FROM node:22-slim
 # Usa NODE_ENV para determinar si es dev o prod
 ARG NODE_ENV
 ENV NODE_ENV=${NODE_ENV:-development}
+ARG NUXT_PUBLIC_BASE_URL
+ENV NUXT_PUBLIC_BASE_URL=${NUXT_PUBLIC_BASE_URL:-http://localhost:3000}
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request updates the Docker build configuration to standardize the use of the `NUXT_PUBLIC_BASE_URL` environment variable instead of the previously used `NUXT_AUTH_BASE_URL`. This change ensures consistency in how the application's base URL is defined and accessed across different environments.

**Docker environment variable updates:**

* Replaced `NUXT_AUTH_BASE_URL` with `NUXT_PUBLIC_BASE_URL` as a build argument and environment variable in the `Dockerfile` to standardize the application's base URL configuration.
* Added `NUXT_PUBLIC_BASE_URL` as a build argument and environment variable in the production image section of the `Dockerfile` for consistent environment setup.