### PR TITLE
🔧 feat: implement useGnoxyUrl function for URL translation and proxy …

### DIFF
--- a/composables/useGnoxyUrl.ts
+++ b/composables/useGnoxyUrl.ts
@@ -1,0 +1,20 @@
+export function useGnoxyUrl() {
+  const config = useRuntimeConfig();
+
+  function gnoxyUrl(inputUrl: string): string {
+    if (!inputUrl) return '';
+    const { geonodeUrl, baseURL } = config.public;
+
+    // Caso 1: URL empieza con geonodeUrl → traducir a gnoxy normal
+    if (inputUrl.startsWith(geonodeUrl)) {
+      return inputUrl.replace(geonodeUrl, `${baseURL}/api/gnoxy`);
+    }
+
+    // Caso 2: cualquier otra URL → usar gnoxy/proxy con encode
+    return `${baseURL}/api/gnoxy/proxy/?url=${encodeURIComponent(inputUrl)}`;
+  }
+
+  return {
+    gnoxyUrl,
+  };
+}


### PR DESCRIPTION
This pull request introduces a new composable utility for generating proxied URLs based on runtime configuration. The main change is the addition of the `useGnoxyUrl` function, which standardizes how URLs are transformed for use with the application's proxy endpoints.

New utility for URL transformation:

* Added a new `useGnoxyUrl` composable in `composables/useGnoxyUrl.ts` that provides a `gnoxyUrl` function to convert input URLs into proxied URLs based on runtime config. This function handles URLs starting with a specific base (`geonodeUrl`) differently from other URLs, ensuring consistent proxying logic throughout the app.