### PR TITLE
Fix/package lock

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run ESLint
         run: npm run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY package.json ./
+RUN npm install
 
 RUN npm ci
 


### PR DESCRIPTION
This pull request updates how dependencies are installed in both the GitHub Actions workflow and the Docker build process. The main changes involve switching from `npm ci` to `npm install` in certain steps, which can affect how dependencies are resolved and installed.

Dependency installation changes:

* [`.github/workflows/docker-compose-develop.yml`](diffhunk://#diff-df0350229a00b492c0728b7dd254cd53fe8d1ee6dbe591553a8cc0aa090747e8L29-R29): Changed the dependency installation step from `npm ci` to `npm install`, which may allow for more flexible dependency resolution but could lead to differences from the lockfile.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22-R23): Modified the Docker build process to copy only `package.json` (instead of both `package.json` and `package-lock.json`) before running `npm install`, and added a separate `npm install` step prior to `npm ci`. This may impact the reproducibility of builds and how dependencies are installed in the Docker image.