### PR TITLE
🔧 fix: add NUXT_PUBLIC_IA_BACKEND_URL to environment variables in doc…

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -116,6 +116,7 @@ jobs:
           echo "NUXT_PUBLIC_GEONODE_API=${{ vars.NUXT_PUBLIC_GEONODE_API }}" >> .env
           echo "NUXT_PUBLIC_GEONODE_URL=${{ vars.NUXT_PUBLIC_GEONODE_URL }}" >> .env
           echo "NUXT_PUBLIC_GEOSERVER_URL=${{ vars.NUXT_PUBLIC_GEOSERVER_URL }}" >> .env
+          echo "NUXT_PUBLIC_IA_BACKEND_URL=${{ vars.NUXT_PUBLIC_IA_BACKEND_URL }}" >> .env
           echo "NUXT_PUBLIC_BASE_URL=${{ vars.NUXT_PUBLIC_BASE_URL }}" >> .env
           echo "NUXT_AUTH_ORIGIN=${{ vars.NUXT_AUTH_ORIGIN }}" >> .env
           echo "KEYCLOAK_ISSUER=${{ vars.KEYCLOAK_ISSUER }}" >> .env
@@ -133,8 +134,9 @@ jobs:
           NUXT_PUBLIC_GEONODE_API: ${{ vars.NUXT_PUBLIC_GEONODE_API }}
           NUXT_PUBLIC_GEONODE_URL: ${{ vars.NUXT_PUBLIC_GEONODE_URL }}
           NUXT_PUBLIC_GEOSERVER_URL: ${{ vars.NUXT_PUBLIC_GEOSERVER_URL }}
-          NUXT_AUTH_ORIGIN: ${{ vars.NUXT_AUTH_ORIGIN }}
+          NUXT_PUBLIC_IA_BACKEND_URL: ${{ vars.NUXT_PUBLIC_IA_BACKEND_URL }}
           NUXT_PUBLIC_BASE_URL: ${{ vars.NUXT_PUBLIC_BASE_URL }}
+          NUXT_AUTH_ORIGIN: ${{ vars.NUXT_AUTH_ORIGIN }}
           KEYCLOAK_ISSUER: ${{ vars.KEYCLOAK_ISSUER }}
           KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
           KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-compose-develop.yml` workflow to support a new environment variable for the IA backend service. The changes ensure that the `NUXT_PUBLIC_IA_BACKEND_URL` variable is included in both the `.env` file setup and the environment variables passed to the job.

Environment variable integration:

* Added `NUXT_PUBLIC_IA_BACKEND_URL` to the `.env` file creation step, so it's available to the application at runtime.
* Included `NUXT_PUBLIC_IA_BACKEND_URL` in the list of environment variables for the workflow job, ensuring it is available during execution.