### PR TITLE
🔧 fix: update Dockerfile to use npm ci for streamlined installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,12 @@ WORKDIR /app
 
 COPY --from=builder /app/.output/ .output/
 COPY --from=builder /app/package.json .
-# COPY --from=builder /app/package-lock.json .
+COPY --from=builder /app/package-lock.json .
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
-    touch package-lock.json &&  \
-    rm -rf package-lock.json && \
-    npm install
+    npm ci --omit=dev -- && \
 
 EXPOSE 3000
 


### PR DESCRIPTION
This pull request updates the Docker build process to ensure more reliable and reproducible installations of Node.js dependencies. The main change is switching from `npm install` to `npm ci`, and properly copying the `package-lock.json` file into the image.

Improvements to Docker build process:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L44-R49): Now copies `package-lock.json` from the builder stage, ensuring the lockfile is available for dependency installation.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L44-R49): Replaces `npm install` with `npm ci --omit=dev`, which installs dependencies strictly according to `package-lock.json` and omits development dependencies, resulting in more consistent and production-ready builds.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L44-R49): Removes unnecessary commands that previously created and deleted a dummy `package-lock.json` file.