### PR TITLE
🔧 fix: remove unnecessary trailing characters from npm ci command in …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=builder /app/package-lock.json .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
-    npm ci --omit=dev -- && \
+    npm ci --omit=dev
 
 EXPOSE 3000
 


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile`, specifically simplifying the `npm ci` command by removing an unnecessary trailing `--` argument. This change should have no functional impact but makes the command cleaner.

- Simplified the `npm ci` command in the `Dockerfile` by removing an unnecessary trailing `--` argument.…Dockerfile