### PR TITLE
Fix/package lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=builder /app/package-lock.json .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
-    npm ci --omit=dev -- && \
+    npm ci --omit=dev
 
 EXPOSE 3000
 


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file, correcting the dependency URL format for `@centrogeomx/sisdai-mapas` to use the `git+https` protocol. This change ensures proper installation of the package from the specified GitHub branch.

* Changed the `@centrogeomx/sisdai-mapas` dependency URL to use the `git+https` protocol for compatibility with npm package installation.