### PR TITLE
🔧 fix: enhance Dockerfile to handle NODE_ENV for package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,16 @@ COPY --from=builder /app/package-lock.json .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
-    npm ci --omit=dev
+    npm ci --omit=dev \
+
+RUN if [ "$NODE_ENV" = "development" ]; then \
+        rm /app/package-lock.json; \
+        npm i; \
+    elif [ "$NODE_ENV" = "production" ]; then \
+        npm ci --omit=dev; \
+    else \
+        echo "NODE_ENV must be either 'development' or 'production'" && exit 1 \
+    fi
 
 EXPOSE 3000
 


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve how Node.js dependencies are installed based on the environment. The main change is to conditionally install dependencies differently for development and production, ensuring the correct setup for each environment and preventing misconfiguration.

**Environment-specific dependency installation:**

* The `Dockerfile` now checks the `NODE_ENV` variable and:
  * Removes `package-lock.json` and runs `npm i` in development to allow for flexible dependency management.
  * Runs `npm ci --omit=dev` in production to ensure a clean, reproducible install without development dependencies.
  * Exits with an error if `NODE_ENV` is not set to either 'development' or 'production'.