### PR TITLE
🔧 fix: streamline Dockerfile npm installation logic for NODE_ENV hand…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,12 @@ COPY --from=builder /app/package-lock.json .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
-    npm ci --omit=dev \
-
-RUN if [ "$NODE_ENV" = "development" ]; then \
-        rm /app/package-lock.json; \
-        npm i; \
+    if [ "$NODE_ENV" = "development" ]; then \
+        rm /app/package-lock.json && npm i; \
     elif [ "$NODE_ENV" = "production" ]; then \
         npm ci --omit=dev; \
     else \
-        echo "NODE_ENV must be either 'development' or 'production'" && exit 1 \
+        echo "NODE_ENV must be either 'development' or 'production'" && exit 1; \
     fi
 
 EXPOSE 3000


### PR DESCRIPTION
This pull request updates the Docker build process to streamline how dependencies are installed based on the `NODE_ENV` environment variable. The logic for installing dependencies in development and production modes has been consolidated for clarity and maintainability.

Dockerfile improvements:

* Combined the development dependency installation logic into a single `RUN` statement, removing redundant commands and improving readability. Now, the script removes `package-lock.json` and runs `npm i` in development, and runs `npm ci --omit=dev` in production.
* Added a missing semicolon at the end of the error branch to ensure proper shell command termination.