### PR TITLE
🔧 fix: update sisdai-mapas dependency URL format in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@centrogeomx/sisdai-componentes": "^4.14.0",
     "@centrogeomx/sisdai-css": "^1.10.0",
-    "@centrogeomx/sisdai-mapas": "git+https://github.com/CentroGeo/sisdai-mapas#fix/wms-fetch",
+    "@centrogeomx/sisdai-mapas": "git+https://github.com/CentroGeo/sisdai-mapas.git#fix/wms-fetch",
     "@nuxt/image": "^1.10.0",
     "@nuxt/scripts": "^0.11.10",
     "@pinia/nuxt": "^0.11.1",


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file, specifically correcting the URL format for the `@centrogeomx/sisdai-mapas` dependency to include the `.git` suffix. This ensures proper resolution and installation of the package from the specified GitHub branch.

- Dependency update:
  * Updated the `@centrogeomx/sisdai-mapas` dependency URL to include `.git`, ensuring correct package installation from the GitHub repository.