### PR TITLE
🔧 fix: add .npmrc to Dockerfile for consistent npm configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ WORKDIR /app
 COPY --from=builder /app/.output/ .output/
 COPY --from=builder /app/package.json .
 COPY --from=builder /app/package-lock.json .
+COPY --from=builder /app/.npmrc .
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-client && \


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process by copying the `.npmrc` configuration file from the builder stage into the final image. This ensures that npm configuration (such as registry settings or authentication) is preserved in the runtime environment.

- Docker build process:
  * Added a step to copy `.npmrc` from the builder image to the final image in the `Dockerfile`.