### PR TITLE
Fix/package lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,22 +40,6 @@ ENV NUXT_PUBLIC_BASE_URL=${NUXT_PUBLIC_BASE_URL:-http://localhost:3000}
 WORKDIR /app
 
 COPY --from=builder /app/.output/ .output/
-COPY --from=builder /app/package.json .
-COPY --from=builder /app/package-lock.json .
-COPY --from=builder /app/.npmrc .npmrc
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git openssh-client && \
-    rm -rf /var/lib/apt/lists/* && \
-    if [ "$NODE_ENV" = "development" ]; then \
-        echo "NODE_ENV is development"; \
-        npm ci --omit=dev; \
-    elif [ "$NODE_ENV" = "production" ]; then \
-        echo "NODE_ENV is production"; \
-        npm ci --omit=dev; \
-    else \
-        echo "NODE_ENV must be either 'development' or 'production'" && exit 1; \
-    fi
 
 EXPOSE 3000
 


### PR DESCRIPTION
This pull request simplifies the Docker build process by removing unnecessary steps related to package management and dependency installation in the final image. The most important change is the elimination of copying package files and running npm install commands, which streamlines the Dockerfile for faster and more secure builds.

Dockerfile simplification:

* Removed copying of `package.json`, `package-lock.json`, and `.npmrc` from the builder stage, as well as all related npm install and environment-specific logic from the final image. This results in a smaller, cleaner, and more secure production image.