### PR TITLE
fix(descarga-mapa)

### DIFF
--- a/pages/consulta/capas.vue
+++ b/pages/consulta/capas.vue
@@ -209,7 +209,7 @@ function AbrirModalDescarga() {
 
       leyendasDescarga.value = owsLayers.value.map((resource) => ({
         ...resource,
-        fuente: findServer(resource),
+        fuente: findServer(resource).replace('?', ''),
         lado: storeSelected.byPk(resource.pk).lado,
         opacidad: storeSelected.byPk(resource.pk).opacidad,
         posicion: storeSelected.byPk(resource.pk).posicion,


### PR DESCRIPTION
Quita los dobles signos de interrogación en la consulta de la leyenda

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/8fff26ae-8138-4a5d-9853-20575a2e5b01" />

