### PR TITLE
fix(docker): copia scripts/ antes de npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --- copiar solo package.json primero ---
 COPY package*.json ./
 
+# scripts necesarios para postinstall
+COPY scripts/ ./scripts/
+
 # instalar dependencias
 RUN npm install --include=dev --legacy-peer-deps \
     && npm cache clean --force


### PR DESCRIPTION
## Summary

- El `postinstall` en `package.json` ejecuta `node scripts/patch-focus-trap.js` durante `npm install`
- El Dockerfile copiaba `package*.json` y corría `npm install`, pero `scripts/` se copiaba después
- Fix: agregar `COPY scripts/ ./scripts/` antes del paso `RUN npm install`

## Test plan

- [ ] El build de Docker en el CI debe completar sin error `MODULE_NOT_FOUND`