### PR TITLE
style: ocultar herramientas de IA y visibilidad de proyectos

### DIFF
--- a/pages/ia/chat/[id]/contexto/[idx].vue
+++ b/pages/ia/chat/[id]/contexto/[idx].vue
@@ -2440,7 +2440,8 @@ onMounted(() => {
                   </div>
                 </div>
               </div>
-              <div class="columna-8">
+              <!-- OCULTO TEMPORALMENTE: Botón Espacializar información -->
+              <!-- <div class="columna-8">
                 <div class="fondo-color-neutro borde-redondeado-8">
                   <div class="flex p-2" style="row-gap: 8px">
                     <div class="columna-16">
@@ -2465,8 +2466,8 @@ onMounted(() => {
                     </div>
                   </div>
                 </div>
-              </div>
-              <!-- COMENTADO: Botón Análisis espacial -->
+              </div> -->
+              <!-- OCULTO TEMPORALMENTE: Botón Análisis espacial -->
               <!-- <div class="columna-8">
                 <div class="fondo-color-neutro borde-redondeado-8">
                   <div class="flex p-2" style="row-gap: 8px">
@@ -2493,7 +2494,7 @@ onMounted(() => {
                   </div>
                 </div>
               </div> -->
-              <!-- COMENTADO: Botón Herramienta -->
+              <!-- OCULTO TEMPORALMENTE: Botón Herramienta -->
               <!-- <div class="columna-8">
                 <div class="fondo-color-neutro borde-redondeado-8">
                   <div class="flex p-2" style="row-gap: 8px">

--- a/pages/ia/proyecto/[id]/configurar.vue
+++ b/pages/ia/proyecto/[id]/configurar.vue
@@ -486,7 +486,8 @@ onBeforeUnmount(() => {
                   :es_obligatorio="false"
                   class="m-b-3"
                 />
-                <SisdaiGrupoBotonesRadio leyenda="Visibilidad">
+                <!-- OCULTO TEMPORALMENTE: Selección de visibilidad del proyecto -->
+                <!-- <SisdaiGrupoBotonesRadio leyenda="Visibilidad">
                   <SisdaiBotonRadio
                     v-model="visibilidadProyecto"
                     etiqueta="Público"
@@ -499,7 +500,7 @@ onBeforeUnmount(() => {
                     value="privado"
                     name="visibilidad"
                   />
-                </SisdaiGrupoBotonesRadio>
+                </SisdaiGrupoBotonesRadio> -->
               </ClientOnly>
             </form>
           </div>

--- a/pages/ia/proyecto/[id]/index.vue
+++ b/pages/ia/proyecto/[id]/index.vue
@@ -317,13 +317,13 @@ watch(
                 <div class="flex proyecto-encabezado">
                   <h2>{{ proyecto.title }}</h2>
 
-                  <p
+                  <!-- OCULTO TEMPORALMENTE: Etiqueta de visibilidad del proyecto (Público/Privado) -->
+                  <!-- <p
                     class="p-x-1 p-y-minimo fondo-color-acento texto-color-secundario borde borde-color-acento borde-redondeado-8"
                   >
                     <span>{{ proyecto.public ? 'Público' : 'Privado' }}</span>
-                    <!-- TODO: agregar icono de para privado/publico -->
                     <span class="pictograma-privado" aria-hidden="true" />
-                  </p>
+                  </p> -->
                 </div>
 
                 <div class="flex">

--- a/pages/ia/proyectos/crear-nuevo.vue
+++ b/pages/ia/proyectos/crear-nuevo.vue
@@ -436,7 +436,8 @@ onMounted(() => {
                   :es_obligatorio="false"
                   class="m-b-3"
                 />
-                <SisdaiGrupoBotonesRadio leyenda="Visibilidad">
+                <!-- OCULTO TEMPORALMENTE: Selección de visibilidad del proyecto -->
+                <!-- <SisdaiGrupoBotonesRadio leyenda="Visibilidad">
                   <SisdaiBotonRadio
                     v-model="visibilidadProyecto"
                     etiqueta="Público"
@@ -449,7 +450,7 @@ onMounted(() => {
                     value="privado"
                     name="visibilidad"
                   />
-                </SisdaiGrupoBotonesRadio>
+                </SisdaiGrupoBotonesRadio> -->
               </ClientOnly>
             </form>
           </div>


### PR DESCRIPTION
Se requirioe simplificar la interfaz del módulo de Inteligencia Artificial para alinearse con los requerimientos institucionales actuales, desactivando temporalmente funciones que no deben estar visibles para el usuario final en esta etapa.

Cambios realizados: 
   1. Herramientas de IA: Se ocultaron los botones de "Espacializar información", "Análisis
      espacial" y "Herramienta" dentro de la interfaz de chat
      (pages/ia/chat/[id]/contexto/[idx].vue).
   2. Gestión de Proyectos: Se removió la opción de elegir visibilidad (Público/Privado) tanto en
      el formulario de creación como en el de configuración de proyectos.
   3. Visualización: Se eliminó la etiqueta de estatus (Público/Privado) en la vista detallada del
      proyecto para evitar confusión.