### PR TITLE
Oculta botón de catálogo y agrega texto de formatos permitidos

### DIFF
--- a/components/ia/Leyenda/LeyendaInicioVistas.vue
+++ b/components/ia/Leyenda/LeyendaInicioVistas.vue
@@ -12,7 +12,7 @@ const storeIA = useIAStore();
           <p class="m-b-0">
             Esta herramienta está diseñada para ayudarte a analizar información científica y
             territorial mediante chats con inteligencia artificial. Para iniciar, crea proyectos
-            temáticos, agregar información del catálogo o subir tus propios archivos.
+            temáticos<!--, agregar información del catálogo--> o subir tus propios archivos.
           </p>
         </div>
         <div class="texto-centrado m-t-3">

--- a/pages/ia/chats/index.vue
+++ b/pages/ia/chats/index.vue
@@ -336,7 +336,7 @@ onMounted(() => {
                 <p class="m-b-0">
                   Esta herramienta está diseñada para ayudarte a analizar información científica y
                   territorial mediante chats con inteligencia artificial. Para iniciar, crea
-                  proyectos temáticos, agregar información del catálogo o subir tus propios
+                  proyectos temáticos<!--, agregar información del catálogo--> o subir tus propios
                   archivos.
                 </p>
               </div>

--- a/pages/ia/proyecto/[id]/configurar.vue
+++ b/pages/ia/proyecto/[id]/configurar.vue
@@ -513,14 +513,14 @@ onBeforeUnmount(() => {
               <h2>Agregar fuentes de información</h2>
 
               <div>
-                <button
+                <!-- <button
                   class="boton-pictograma boton-primario m-r-2"
                   aria-label="Agregar fuentes del catalogo"
                   @click="agregarFuentesCatalogo"
                 >
                   Agregar del catálogo
                   <span class="pictograma-agregar" aria-hidden="true" />
-                </button>
+                </button> -->
 
                 <button
                   class="boton-pictograma boton-primario"
@@ -616,7 +616,7 @@ onBeforeUnmount(() => {
       </main>
 
       <ClientOnly>
-        <SisdaiModal ref="agregaCatalogoModal">
+        <!-- <SisdaiModal ref="agregaCatalogoModal">
           <template #encabezado>
             <h2>Agregar información del catálogo</h2>
           </template>
@@ -845,7 +845,7 @@ onBeforeUnmount(() => {
               Aceptar
             </button>
           </template>
-        </SisdaiModal>
+        </SisdaiModal> -->
 
         <SisdaiModal id="loaderModal" ref="loaderModal">
           <template #encabezado>

--- a/pages/ia/proyecto/[id]/configurar.vue
+++ b/pages/ia/proyecto/[id]/configurar.vue
@@ -1,7 +1,5 @@
 <script setup>
 import SisdaiAreaTexto from '@centrogeomx/sisdai-componentes/src/componentes/area-texto/SisdaiAreaTexto.vue';
-import SisdaiGrupoBotonesRadio from '@centrogeomx/sisdai-componentes/src/componentes/boton-radio-grupo/SisdaiBotonesRadioGrupo.vue';
-import SisdaiBotonRadio from '@centrogeomx/sisdai-componentes/src/componentes/boton-radio/SisdaiBotonRadio.vue';
 import SisdaiCampoBase from '@centrogeomx/sisdai-componentes/src/componentes/campo-base/SisdaiCampoBase.vue';
 import SisdaiModal from '@centrogeomx/sisdai-componentes/src/componentes/modal/SisdaiModal.vue';
 
@@ -538,6 +536,9 @@ onBeforeUnmount(() => {
                   style="display: none"
                   @change="manejarSeleccionArchivos"
                 />
+                <p class="m-y-1 texto-derecha">
+                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                </p>
               </div>
             </div>
 

--- a/pages/ia/proyecto/[id]/crear-contexto.vue
+++ b/pages/ia/proyecto/[id]/crear-contexto.vue
@@ -398,7 +398,7 @@ onUnmounted(() => {
                     </td>
                     <td class="p-3 etiqueta-tabla">
                       <span class="p-x-1 p-y-minimo">
-                        {{ fuente.geonode_type === 'Catalogo' ? 'Catálogo' : fuente.geonode_type }}
+                        {{ fuente.geonode_type === 'Catalogo' ? 'Propio' : fuente.geonode_type }}
                       </span>
                     </td>
                   </tr>

--- a/pages/ia/proyecto/[id]/index.vue
+++ b/pages/ia/proyecto/[id]/index.vue
@@ -500,7 +500,7 @@ watch(
                       <td class="p-3 etiqueta-tabla">
                         <span class="p-x-1 p-y-minimo">
                           {{
-                            archivo.geonode_type === 'Catalogo' ? 'Catálogo' : archivo.geonode_type
+                            archivo.geonode_type === 'Catalogo' ? 'Propio' : archivo.geonode_type
                           }}
                         </span>
                       </td>

--- a/pages/ia/proyectos/crear-nuevo.vue
+++ b/pages/ia/proyectos/crear-nuevo.vue
@@ -463,14 +463,14 @@ onMounted(() => {
               <h2>Agregar fuentes de información</h2>
 
               <div>
-                <button
+                <!-- <button
                   class="boton-pictograma boton-primario m-r-2"
                   aria-label="Agregar fuentes del catalogo"
                   @click="agregarFuentesCatalogo"
                 >
                   Agregar del catálogo
                   <span class="pictograma-agregar" aria-hidden="true" />
-                </button>
+                </button> -->
 
                 <button
                   class="boton-pictograma boton-primario"

--- a/pages/ia/proyectos/crear-nuevo.vue
+++ b/pages/ia/proyectos/crear-nuevo.vue
@@ -480,6 +480,7 @@ onMounted(() => {
                   Subir archivos
                   <span class="pictograma-archivo-subir" aria-hidden="true" />
                 </button>
+
                 <input
                   ref="fileInput"
                   type="file"
@@ -488,6 +489,9 @@ onMounted(() => {
                   style="display: none"
                   @change="manejarSeleccionArchivos"
                 />
+                <p class="m-y-1 texto-derecha">
+                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                </p>
               </div>
             </div>
 

--- a/pages/ia/proyectos/index.vue
+++ b/pages/ia/proyectos/index.vue
@@ -87,7 +87,7 @@ onMounted(() => {
               <p class="m-b-0">
                 Esta herramienta está diseñada para ayudarte a analizar información científica y
                 territorial mediante chats con inteligencia artificial. Para iniciar, crea proyectos
-                temáticos, agregar información del catálogo o subir tus propios archivos.
+                temáticos<!--, agregar información del catálogo--> o subir tus propios archivos.
               </p>
             </div>
 


### PR DESCRIPTION
Se oculta la posibilidad de añadir archivos desde el catálogo dentro del módulo de Inteligencia Artificial, para simplificar la interfaz y que el usuario solo vea las opciones activas (como subir archivos propios).
**Cambios principales:**
- Botones ocultos: Ya no aparecen los botones de "Agregar del catálogo" cuando creas o configuras un proyecto de IA.
- Textos corregidos: Se quitaron las menciones al "catálogo" en los textos de bienvenida y ayuda de las pantallas de proyectos y chats.
- Modales desactivados: Se comentaron las ventanas emergentes que servían para buscar y seleccionar archivos del catálogo.
- Etiquetas de archivos: Para no confundir al usuario, los archivos que ya estaban agregados ahora muestran la etiqueta "Propio" en lugar de "Catálogo".