### PR TITLE
docs: actualizar descripción de IA y soporte de documentos Word en in…

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -185,9 +185,9 @@ watch(
                 aplicar filtros por región y periodo, y exportar el resultado. Cabe resaltar que no
                 es un sistema SIG en su totalidad; está orientado a consulta y visualización, no a
                 edición avanzada de geometrías. Admite capas vectoriales (Shapefile, GeoJSON) y
-                tabulares con coordenadas (CSV con latitud/longitud). Las capas públicas del
-                catálogo son de libre consulta; para subir capas propias o guardar mapas, se
-                requiere una cuenta SIGIC activa.
+                archivos tabulares (CSV con latitud/longitud). Las capas públicas del catálogo son
+                de libre consulta; para subir capas propias o guardar mapas, se requiere una cuenta
+                SIGIC activa.
               </p>
             </div>
             <div class="columna-8">
@@ -216,9 +216,9 @@ watch(
                 La IA puede resumir documentos, comparar contenidos entre fuentes, extraer datos
                 clave y responder preguntas sobre la información que el usuario le proporcione
                 dentro de un proyecto. Las respuestas incluyen referencias a los párrafos o
-                secciones de origen. Admite documentos PDF, archivos de texto (.txt) y tablas (CSV).
-                Se requiere una cuenta SIGIC activa y el uso de la IA está sujeto a disponibilidad
-                del servicio.
+                secciones de origen. Admite documentos PDF, archivos Word (.doc, .docx) y tablas
+                (.csv). Se requiere una cuenta SIGIC activa y el uso de la IA está sujeto a
+                disponibilidad del servicio.
               </p>
             </div>
           </div>


### PR DESCRIPTION

   1. Se actualizó la descripción del módulo de Inteligencia Artificial para detallar las funciones de
     resumen, comparación y extracción de datos clave con referencias a fuentes originales.
   2. Se incluyó explícitamente el soporte para archivos de Microsoft Word (.doc y .docx) en las secciones
     de análisis con IA y carga de archivos personales.
   3. Se estandarizó el lenguaje técnico en la sección de exploración territorial, sustituyendo "tabulares
     con coordenadas" por "archivos tabulares" para mayor claridad del usuario.
   4.  Se añadieron notas sobre los requisitos de uso: cuenta SIGIC activa y sujeción a la disponibilidad
     del servicio de IA.
5. Se corrigió la redacción general para asegurar la coherencia informativa en todo el dashboard de
     inicio.