### PR TITLE
Descarga de mapa en modo oscuro

### DIFF
--- a/components/consulta/MapaDescarga.vue
+++ b/components/consulta/MapaDescarga.vue
@@ -1,11 +1,5 @@
 <script setup>
-import {
-  // SisdaiCapaArcgis,
-  // SisdaiCapaWms,
-  // SisdaiCapaXyz,
-  // SisdaiLeyendaArcgis,
-  SisdaiLeyendaWms,
-} from '@centrogeomx/sisdai-mapas';
+import { SisdaiLeyendaWms } from '@centrogeomx/sisdai-mapas';
 
 const props = defineProps({
   funcionConsulta: {
@@ -77,9 +71,18 @@ function CargaCompleta(idx, v) {
   </div>
 </template>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.mapa-descarga {
+  background-color: #fff;
+  color: #000;
+}
+</style>
 
 <style>
+.mapa-descarga .sisdai-mapa-leyenda .lectura {
+  color: #000;
+}
+
 .mapa-descarga
   .sisdai-mapa
   .contenedor-vis-paneles


### PR DESCRIPTION
El estilo de de descarga es en modo claro siempre


<img width="1352" height="878" alt="image" src="https://github.com/user-attachments/assets/d43d892c-a2a8-481e-9ea4-d9db6fd4bb3a" />
