### PR TITLE
feat(tableros): migrar modales de admin a ModalBase nativo

### DIFF
--- a/components/tableros/admin/ArbolGrupo.vue
+++ b/components/tableros/admin/ArbolGrupo.vue
@@ -281,7 +281,7 @@ onMounted(cargarDetalle);
             @dragover.prevent
             @drop.prevent="onDropSubgrupo($event, sg.id)"
           >
-            <header>
+            <div class="arbol-grupo__subgrupo-cab">
               <template v-if="subgrupoEditandoId === sg.id">
                 <form class="arbol-grupo__subgrupo-form" @submit.prevent="guardarSubgrupo(sg.id)">
                   <input
@@ -315,7 +315,8 @@ onMounted(cargarDetalle);
                   title="Editar subgrupo"
                   @click="abrirEdicionSubgrupo(sg)"
                 >
-                  <span class="pictograma-editar" />
+                  <span class="pictograma-editar m-r-1" />
+                  Editar
                 </button>
                 <button
                   type="button"
@@ -325,7 +326,7 @@ onMounted(cargarDetalle);
                   <span class="pictograma-eliminar" />
                 </button>
               </template>
-            </header>
+            </div>
             <ul v-if="sg.indicators?.length">
               <li v-for="ind in sg.indicators" :key="ind.id">
                 <span class="pictograma-reporte m-r-1" />
@@ -439,7 +440,7 @@ onMounted(cargarDetalle);
     border-radius: 4px;
     color: #111;
 
-    header {
+    &-cab {
       display: flex;
       align-items: center;
       gap: 0.5rem;

--- a/components/tableros/admin/FormularioCuadroDatos.vue
+++ b/components/tableros/admin/FormularioCuadroDatos.vue
@@ -1,6 +1,4 @@
 <script setup>
-import SisdaiModal from '@centrogeomx/sisdai-componentes/src/componentes/modal/SisdaiModal.vue';
-
 const props = defineProps({
   indicadorId: {
     type: Number,
@@ -106,7 +104,7 @@ async function guardar() {
 
     if (data?.id) {
       emit('guardado', data);
-      modal.value?.cerrarModal();
+      modal.value?.cerrar();
     } else {
       error.value = data?.detail || JSON.stringify(data);
     }
@@ -117,65 +115,91 @@ async function guardar() {
   }
 }
 
-onMounted(async () => {
-  cargarDesdeCuadro();
-  await nextTick();
-  modal.value?.abrirModal();
-});
+watch(
+  () => modal.value,
+  (m) => {
+    if (m) {
+      cargarDesdeCuadro();
+      m.abrir();
+    }
+  },
+  { once: true }
+);
 </script>
 
 <template>
   <ClientOnly>
-    <SisdaiModal ref="modal" @cerrar="emit('cerrar')">
+    <TablerosAdminModalBase ref="modal" ancho="760px" @cerrar="emit('cerrar')">
       <template #encabezado>
         <h2>{{ esEdicion ? 'Editar' : 'Crear' }} cuadro de datos</h2>
       </template>
 
       <template #cuerpo>
         <form @submit.prevent="guardar">
-          <div class="m-b-2">
-            <label for="cd-field">Campo de información</label>
-            <input
-              id="cd-field"
-              v-model="formulario.field"
-              type="text"
-              placeholder="Ej: poblacion_total"
-              required
-            />
+          <!-- ── Datos del indicador ── -->
+          <div class="seccion-titulo">Datos del indicador</div>
+          <div class="form-grid-2">
+            <div class="campo">
+              <label for="cd-field">Campo de información <span class="requerido">*</span></label>
+              <input
+                id="cd-field"
+                v-model="formulario.field"
+                type="text"
+                placeholder="Ej: poblacion_total"
+                required
+              />
+            </div>
+            <div class="campo">
+              <label for="cd-name">Nombre personalizado <span class="requerido">*</span></label>
+              <input id="cd-name" v-model="formulario.name" type="text" required />
+            </div>
           </div>
 
-          <div class="m-b-2">
-            <label for="cd-name">Nombre personalizado</label>
-            <input id="cd-name" v-model="formulario.name" type="text" required />
+          <div class="check-row m-t-2">
+            <label class="check-inline">
+              <input id="cd-percentage" v-model="formulario.is_percentage" type="checkbox" />
+              ¿Es porcentual?
+            </label>
           </div>
 
-          <div class="m-b-2">
-            <input id="cd-percentage" v-model="formulario.is_percentage" type="checkbox" />
-            <label for="cd-percentage">¿Es porcentual?</label>
-          </div>
-
-          <div v-if="formulario.is_percentage" class="m-b-2">
+          <div v-if="formulario.is_percentage" class="campo m-t-2">
             <label for="cd-total">Campo total para calcular porcentaje</label>
             <input id="cd-total" v-model="formulario.field_percentage_total" type="text" />
           </div>
 
-          <div class="flex flex-contenido-separado m-b-2">
-            <div>
-              <label for="cd-color">Color de fondo</label>
-              <input id="cd-color" v-model="formulario.color" type="color" />
+          <!-- ── Apariencia ── -->
+          <div class="seccion-titulo m-t-4">Apariencia</div>
+
+          <div class="colores-fila">
+            <div class="campo-color">
+              <label for="cd-color">Fondo</label>
+              <input id="cd-color" v-model="formulario.color" type="color" class="input-color" />
+              <span class="color-hex">{{ formulario.color }}</span>
             </div>
-            <div>
-              <label for="cd-text">Color de texto</label>
-              <input id="cd-text" v-model="formulario.text_color" type="color" />
+            <div class="campo-color">
+              <label for="cd-text">Texto</label>
+              <input
+                id="cd-text"
+                v-model="formulario.text_color"
+                type="color"
+                class="input-color"
+              />
+              <span class="color-hex">{{ formulario.text_color }}</span>
             </div>
-            <div>
-              <label for="cd-edge-color">Color de borde</label>
-              <input id="cd-edge-color" v-model="formulario.edge_color" type="color" />
+            <div class="campo-color">
+              <label for="cd-edge-color">Borde</label>
+              <input
+                id="cd-edge-color"
+                v-model="formulario.edge_color"
+                type="color"
+                class="input-color"
+              />
+              <span class="color-hex">{{ formulario.edge_color }}</span>
             </div>
           </div>
 
-          <div class="flex flex-contenido-separado m-b-2">
-            <div>
+          <div class="form-grid-2 m-t-3">
+            <div class="campo">
               <label for="cd-size">Tamaño</label>
               <select id="cd-size" v-model="formulario.size">
                 <option v-for="t in TAMANIOS" :key="t.value" :value="t.value">
@@ -183,8 +207,7 @@ onMounted(async () => {
                 </option>
               </select>
             </div>
-
-            <div>
+            <div class="campo">
               <label for="cd-edge">Estilo de borde</label>
               <select id="cd-edge" v-model="formulario.edge_style">
                 <option v-for="b in BORDES" :key="b.value" :value="b.value">{{ b.label }}</option>
@@ -192,55 +215,45 @@ onMounted(async () => {
             </div>
           </div>
 
-          <div class="m-b-2">
-            <label for="cd-icon">Icono (clase Font Awesome / Material)</label>
-            <input
-              id="cd-icon"
-              v-model="formulario.icon"
-              type="text"
-              placeholder="Ej: fas fa-users"
-            />
+          <!-- ── Ícono ── -->
+          <div class="seccion-titulo m-t-4">Ícono</div>
+          <div class="campo">
+            <label>Seleccionar del catálogo</label>
+            <TablerosAdminPickerIcono v-model="formulario.icon" />
           </div>
-
-          <div class="m-b-2">
-            <label for="cd-icon-custom">O subir icono personalizado</label>
+          <div class="campo m-t-2">
+            <label for="cd-icon-custom">O subir ícono personalizado</label>
             <input id="cd-icon-custom" type="file" accept="image/*" @change="onArchivoIcono" />
             <img
               v-if="previewIcono"
               :src="previewIcono"
-              alt="Preview"
-              style="width: 40px; height: 40px; margin-top: 0.5rem"
+              alt="Preview del ícono"
+              class="icono-preview"
             />
           </div>
 
-          <section class="m-b-3">
-            <h4>Vista previa</h4>
-            <div
-              :style="{
-                background: formulario.color,
-                color: formulario.text_color,
-                borderColor: formulario.edge_color,
-                padding: '1rem',
-                borderRadius: '8px',
-                borderWidth: '2px',
-                borderStyle: 'solid',
-                maxWidth: '240px',
-              }"
-            >
-              <div style="display: flex; align-items: center; gap: 0.5rem">
-                <span v-if="formulario.icon" :class="formulario.icon" style="font-size: 1.5rem" />
-                <strong>{{ formulario.name || 'Nombre' }}</strong>
-              </div>
-              <p style="margin: 0.3rem 0 0; font-size: 0.85rem">
-                {{ formulario.field || 'campo' }}
-                {{ formulario.is_percentage ? '(%)' : '' }}
-              </p>
+          <!-- ── Vista previa ── -->
+          <div class="seccion-titulo m-t-4">Vista previa</div>
+          <div
+            class="cuadro-preview"
+            :style="{
+              background: formulario.color,
+              color: formulario.text_color,
+              borderColor: formulario.edge_color,
+            }"
+          >
+            <div class="cuadro-preview__titulo">
+              <span v-if="formulario.icon" :class="formulario.icon" class="cuadro-preview__icono" />
+              <strong>{{ formulario.name || 'Nombre del cuadro' }}</strong>
             </div>
-          </section>
+            <p class="cuadro-preview__campo">
+              {{ formulario.field || 'campo' }}{{ formulario.is_percentage ? ' (%)' : '' }}
+            </p>
+          </div>
 
-          <p v-if="error" class="color-error">{{ error }}</p>
+          <p v-if="error" class="color-error m-t-2">{{ error }}</p>
 
-          <div class="flex flex-contenido-separado">
+          <div class="acciones-modal">
             <button type="button" class="boton boton-secundario" @click="emit('cerrar')">
               Cancelar
             </button>
@@ -253,6 +266,126 @@ onMounted(async () => {
           </div>
         </form>
       </template>
-    </SisdaiModal>
+    </TablerosAdminModalBase>
   </ClientOnly>
 </template>
+
+<style lang="scss" scoped>
+.seccion-titulo {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-texto-secundario, #777);
+  border-bottom: 1px solid var(--color-borde, #e8e8e8);
+  padding-bottom: 4px;
+  margin-bottom: 1rem;
+}
+
+.form-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.check-row {
+  display: flex;
+  gap: 1rem;
+}
+
+.check-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.colores-fila {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.campo-color {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  label {
+    font-size: 0.85rem;
+    color: var(--color-texto-secundario, #666);
+    min-width: 36px;
+  }
+}
+
+.input-color {
+  width: 40px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid var(--color-borde, #ccc);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.color-hex {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: var(--color-texto-secundario, #888);
+}
+
+.icono-preview {
+  width: 40px;
+  height: 40px;
+  margin-top: 0.25rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-borde, #ccc);
+}
+
+.cuadro-preview {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border-width: 2px;
+  border-style: solid;
+  min-width: 200px;
+  max-width: 280px;
+
+  &__titulo {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  &__icono {
+    font-size: 1.4rem;
+  }
+
+  &__campo {
+    margin: 0;
+    font-size: 0.82rem;
+    opacity: 0.85;
+  }
+}
+
+.acciones-modal {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-borde, #e8e8e8);
+}
+
+.requerido {
+  color: var(--color-primario-4, #991f47);
+}
+</style>

--- a/components/tableros/admin/FormularioIndicador.vue
+++ b/components/tableros/admin/FormularioIndicador.vue
@@ -1,6 +1,4 @@
 <script setup>
-import SisdaiModal from '@centrogeomx/sisdai-componentes/src/componentes/modal/SisdaiModal.vue';
-
 const props = defineProps({
   indicador: {
     type: Object,
@@ -17,12 +15,6 @@ const modal = ref(null);
 const guardando = ref(false);
 const error = ref('');
 
-const TIPOS_GRAFICA = [
-  { value: 'bar', label: 'Barras' },
-  { value: 'donut', label: 'Dona (categórico)' },
-  { value: 'histogram', label: 'Histograma' },
-];
-
 const PALETAS = [
   { value: 'azules_3', label: 'Azules' },
   { value: 'cafes', label: 'Cafés' },
@@ -35,31 +27,108 @@ const PALETAS = [
   { value: 'semaforo_3', label: 'Semáforo 3 tonos' },
 ];
 
+const TIPOS_GRAFICA = [
+  {
+    group: 'Barras',
+    options: [
+      { value: 'bar', label: 'Barras verticales' },
+      { value: 'horizontal_bar', label: 'Barras horizontales' },
+      { value: 'histogram', label: 'Histograma' },
+    ],
+  },
+  {
+    group: 'Circular',
+    options: [
+      { value: 'donut', label: 'Dona' },
+      { value: 'pie', label: 'Pastel (pie)' },
+    ],
+  },
+  {
+    group: 'Líneas y área',
+    options: [
+      { value: 'line', label: 'Línea' },
+      { value: 'area', label: 'Área' },
+    ],
+  },
+  {
+    group: 'Otros',
+    options: [
+      { value: 'scatter', label: 'Dispersión (scatter)' },
+      { value: 'gauge', label: 'Gauge' },
+      { value: 'radar', label: 'Radar' },
+      { value: 'treemap', label: 'Mapa de árbol' },
+    ],
+  },
+];
+
+const METODOS = [
+  { value: 'quantile', label: 'Cuantiles' },
+  { value: 'jenks', label: 'Jenks (natural breaks)' },
+  { value: 'equal', label: 'Intervalos iguales' },
+  { value: 'manual', label: 'Manual' },
+];
+
 const formulario = reactive({
   name: '',
   info_text: '',
   plot_type: 'bar',
   colors: 'azules_3',
+  reverse_colors: false,
+  category_method: 'quantile',
+  field_category: 5,
+  use_single_field: true,
+  show_general_values: false,
+  high_values_percentage: 10,
 });
 
-onMounted(async () => {
+function cargarDesdeIndicador() {
   formulario.name = props.indicador.name || '';
   formulario.info_text = props.indicador.info_text || '';
   formulario.plot_type = props.indicador.plot_type || 'bar';
-  formulario.colors = props.indicador.colors || 'azules_3';
-  await nextTick();
-  modal.value?.abrirModal();
-});
+  const rawColors = props.indicador.colors || 'azules_3';
+  formulario.reverse_colors = rawColors.endsWith('_r');
+  formulario.colors = formulario.reverse_colors ? rawColors.slice(0, -2) : rawColors;
+  formulario.category_method = props.indicador.category_method || 'quantile';
+  formulario.field_category = props.indicador.field_category ?? 5;
+  formulario.use_single_field = props.indicador.use_single_field ?? true;
+  formulario.show_general_values = props.indicador.show_general_values ?? false;
+  formulario.high_values_percentage = props.indicador.high_values_percentage ?? 10;
+}
+
+watch(
+  () => modal.value,
+  (m) => {
+    if (m) {
+      cargarDesdeIndicador();
+      m.abrir();
+    }
+  },
+  { once: true }
+);
 
 async function guardar() {
   error.value = '';
   guardando.value = true;
   try {
     const token = userData.value?.accessToken;
-    const data = await actualizarIndicador(props.indicador.id, formulario, token);
+    const colorsValue = formulario.reverse_colors ? `${formulario.colors}_r` : formulario.colors;
+
+    const payload = {
+      name: formulario.name,
+      info_text: formulario.info_text,
+      plot_type: formulario.plot_type,
+      colors: colorsValue,
+      category_method: formulario.category_method,
+      field_category: formulario.field_category,
+      use_single_field: formulario.use_single_field,
+      show_general_values: formulario.show_general_values,
+      high_values_percentage: formulario.high_values_percentage,
+    };
+
+    const data = await actualizarIndicador(props.indicador.id, payload, token);
     if (data?.id) {
       emit('guardado', data);
-      modal.value?.cerrarModal();
+      modal.value?.cerrar();
     } else {
       error.value = data?.detail || JSON.stringify(data);
     }
@@ -73,19 +142,20 @@ async function guardar() {
 
 <template>
   <ClientOnly>
-    <SisdaiModal ref="modal" @cerrar="emit('cerrar')">
+    <TablerosAdminModalBase ref="modal" ancho="720px" @cerrar="emit('cerrar')">
       <template #encabezado>
         <h2>Editar indicador</h2>
       </template>
 
       <template #cuerpo>
         <form @submit.prevent="guardar">
-          <div class="m-b-2">
-            <label for="ind-nombre">Nombre del indicador</label>
+          <!-- ── Identificación ── -->
+          <div class="seccion-titulo">Identificación</div>
+          <div class="campo m-b-2">
+            <label for="ind-nombre">Nombre del indicador <span class="requerido">*</span></label>
             <input id="ind-nombre" v-model="formulario.name" type="text" required />
           </div>
-
-          <div class="m-b-2">
+          <div class="campo">
             <label for="ind-info">Texto descriptivo</label>
             <textarea
               id="ind-info"
@@ -95,27 +165,80 @@ async function guardar() {
             />
           </div>
 
-          <div class="m-b-2">
-            <label for="ind-tipo">Tipo de gráfica</label>
-            <select id="ind-tipo" v-model="formulario.plot_type">
-              <option v-for="t in TIPOS_GRAFICA" :key="t.value" :value="t.value">
-                {{ t.label }}
-              </option>
-            </select>
+          <!-- ── Visualización ── -->
+          <div class="seccion-titulo m-t-4">Visualización</div>
+          <div class="form-grid-2">
+            <div class="campo">
+              <label for="ind-tipo">Tipo de gráfica</label>
+              <select id="ind-tipo" v-model="formulario.plot_type">
+                <optgroup v-for="g in TIPOS_GRAFICA" :key="g.group" :label="g.group">
+                  <option v-for="t in g.options" :key="t.value" :value="t.value">
+                    {{ t.label }}
+                  </option>
+                </optgroup>
+              </select>
+            </div>
+            <div class="campo">
+              <label for="ind-paleta">Paleta de colores</label>
+              <select id="ind-paleta" v-model="formulario.colors">
+                <option v-for="p in PALETAS" :key="p.value" :value="p.value">
+                  {{ p.label }}
+                </option>
+              </select>
+              <label class="check-inline m-t-1">
+                <input v-model="formulario.reverse_colors" type="checkbox" />
+                Invertir paleta
+              </label>
+            </div>
           </div>
 
-          <div class="m-b-3">
-            <label for="ind-paleta">Paleta de colores</label>
-            <select id="ind-paleta" v-model="formulario.colors">
-              <option v-for="p in PALETAS" :key="p.value" :value="p.value">
-                {{ p.label }}
-              </option>
-            </select>
+          <!-- ── Clasificación ── -->
+          <div class="seccion-titulo m-t-4">Clasificación</div>
+          <div class="form-grid-2">
+            <div class="campo">
+              <label for="ind-method">Método</label>
+              <select id="ind-method" v-model="formulario.category_method">
+                <option v-for="m in METODOS" :key="m.value" :value="m.value">{{ m.label }}</option>
+              </select>
+            </div>
+            <div class="campo">
+              <label for="ind-clases">Número de clases</label>
+              <input
+                id="ind-clases"
+                v-model.number="formulario.field_category"
+                type="number"
+                min="2"
+                max="10"
+              />
+            </div>
+          </div>
+          <div class="campo m-t-2">
+            <label for="ind-high-pct">% de geometrías a recuperar (top values)</label>
+            <input
+              id="ind-high-pct"
+              v-model.number="formulario.high_values_percentage"
+              type="number"
+              min="1"
+              max="100"
+            />
           </div>
 
-          <p v-if="error" class="color-error">{{ error }}</p>
+          <!-- ── Opciones ── -->
+          <div class="seccion-titulo m-t-4">Opciones</div>
+          <div class="checks-col">
+            <label class="check-inline">
+              <input v-model="formulario.use_single_field" type="checkbox" />
+              Usar campo único para gráfica
+            </label>
+            <label class="check-inline">
+              <input v-model="formulario.show_general_values" type="checkbox" />
+              Mostrar valores generales
+            </label>
+          </div>
 
-          <div class="flex flex-contenido-separado">
+          <p v-if="error" class="color-error m-t-2">{{ error }}</p>
+
+          <div class="acciones-modal">
             <button type="button" class="boton boton-secundario" @click="emit('cerrar')">
               Cancelar
             </button>
@@ -128,6 +251,58 @@ async function guardar() {
           </div>
         </form>
       </template>
-    </SisdaiModal>
+    </TablerosAdminModalBase>
   </ClientOnly>
 </template>
+
+<style lang="scss" scoped>
+.seccion-titulo {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-texto-secundario, #777);
+  border-bottom: 1px solid var(--color-borde, #e8e8e8);
+  padding-bottom: 4px;
+  margin-bottom: 1rem;
+}
+
+.form-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.checks-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.check-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.acciones-modal {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-borde, #e8e8e8);
+}
+
+.requerido {
+  color: var(--color-primario-4, #991f47);
+}
+</style>

--- a/components/tableros/admin/ModalBase.vue
+++ b/components/tableros/admin/ModalBase.vue
@@ -1,0 +1,125 @@
+<script setup>
+const emit = defineEmits(['cerrar']);
+
+defineProps({
+  ancho: { type: String, default: '900px' },
+});
+
+const dialogRef = ref(null);
+
+function abrir() {
+  document.body.classList.add('overflow-hidden');
+  dialogRef.value?.showModal();
+}
+
+function cerrar() {
+  document.body.classList.remove('overflow-hidden');
+  dialogRef.value?.close();
+  emit('cerrar');
+}
+
+onMounted(() => {
+  // Escape nativo: prevenimos el cierre automático del <dialog> y emitimos nosotros
+  dialogRef.value?.addEventListener('cancel', (e) => {
+    e.preventDefault();
+    cerrar();
+  });
+});
+
+defineExpose({ abrir, cerrar });
+</script>
+
+<template>
+  <dialog ref="dialogRef" class="modal-base" :style="`--modal-ancho: ${ancho}`">
+    <div class="modal-base__contenedor">
+      <div class="modal-base__cabecera">
+        <slot name="encabezado" />
+        <button type="button" class="modal-base__btn-cerrar" aria-label="Cerrar" @click="cerrar">
+          <span class="pictograma-cerrar" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div class="modal-base__cuerpo">
+        <slot name="cuerpo" />
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<style lang="scss" scoped>
+.modal-base {
+  --modal-ancho: 900px;
+  width: min(var(--modal-ancho), 96vw);
+  max-height: 90vh;
+  padding: 0;
+  border: none;
+  border-radius: 10px;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.22);
+  overflow: hidden;
+  background: var(--color-fondo-1, #fff);
+
+  &::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+  }
+
+  &__contenedor {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+
+  &__cabecera {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: var(--color-fondo-1, #fff);
+    border-bottom: 2px solid var(--color-primario-4, #991f47);
+
+    :deep(h2),
+    :deep(h3) {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: var(--color-primario-4, #991f47);
+    }
+  }
+
+  &__btn-cerrar {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    color: var(--color-texto-secundario, #666);
+    transition:
+      background 0.15s,
+      color 0.15s;
+
+    &:hover {
+      background: var(--color-secundario-3, #f8e1e8);
+      color: var(--color-primario-4, #991f47);
+    }
+
+    .pictograma-cerrar {
+      font-size: 1.1rem;
+    }
+  }
+
+  &__cuerpo {
+    overflow-y: auto;
+    padding: 1.5rem;
+    flex: 1;
+  }
+}
+</style>

--- a/components/tableros/admin/ModalIdentidadVisual.vue
+++ b/components/tableros/admin/ModalIdentidadVisual.vue
@@ -1,11 +1,6 @@
 <script setup>
-import SisdaiModal from '@centrogeomx/sisdai-componentes/src/componentes/modal/SisdaiModal.vue';
-
 const props = defineProps({
-  siteId: {
-    type: Number,
-    required: true,
-  },
+  siteId: { type: Number, required: true },
 });
 
 const { data: userData } = useAuth();
@@ -53,14 +48,14 @@ async function cargar() {
 
 async function abrir() {
   await cargar();
-  modal.value?.abrirModal();
+  modal.value?.abrir();
 }
 
 async function guardar() {
   guardando.value = true;
   try {
     await actualizarConfigSitio(props.siteId, config, userData.value?.accessToken);
-    modal.value?.cerrarModal();
+    modal.value?.cerrar();
   } catch (e) {
     console.error('Error al guardar configuración:', e);
   } finally {
@@ -73,130 +68,259 @@ defineExpose({ abrir });
 
 <template>
   <ClientOnly>
-    <SisdaiModal ref="modal">
+    <TablerosAdminModalBase ref="modal" ancho="820px">
       <template #encabezado>
         <h2>Identidad visual del sitio</h2>
       </template>
 
       <template #cuerpo>
         <form @submit.prevent="guardar">
-          <section class="m-b-4">
-            <h3>Configuración global</h3>
-
-            <div class="m-b-3">
-              <label for="modal-vis-fuente">Tipo de letra</label>
-              <select id="modal-vis-fuente" v-model="config.site_font_style">
+          <!-- ── Tipografía ── -->
+          <div class="seccion-titulo">Tipografía</div>
+          <div class="form-grid-3">
+            <div class="campo col-span-1">
+              <label for="vis-fuente">Tipo de letra</label>
+              <select id="vis-fuente" v-model="config.site_font_style">
                 <option v-for="f in FUENTES" :key="f" :value="f">{{ f }}</option>
               </select>
             </div>
+            <div class="campo">
+              <label for="vis-size">Tamaño general (px)</label>
+              <input
+                id="vis-size"
+                v-model.number="config.site_font_size"
+                type="number"
+                min="10"
+                max="32"
+              />
+            </div>
+            <div class="campo">
+              <label for="vis-hsize">Tamaño encabezado (px)</label>
+              <input
+                id="vis-hsize"
+                v-model.number="config.header_font_size"
+                type="number"
+                min="14"
+                max="60"
+              />
+            </div>
+          </div>
+          <div class="campo m-t-2">
+            <label for="vis-ibt">Título del recuadro de indicadores</label>
+            <input id="vis-ibt" v-model="config.indicator_box_title" type="text" />
+          </div>
 
-            <div class="flex flex-contenido-separado m-b-3">
-              <div>
-                <label for="modal-vis-size">Tamaño de fuente general (px)</label>
-                <input
-                  id="modal-vis-size"
-                  v-model.number="config.site_font_size"
-                  type="number"
-                  min="10"
-                  max="32"
-                />
+          <!-- ── Colores ── -->
+          <div class="seccion-titulo m-t-4">Colores</div>
+          <div class="colores-grid">
+            <div class="colores-seccion">
+              <div class="colores-seccion__titulo">
+                <label class="check-inline">
+                  <input v-model="config.show_header" type="checkbox" />
+                  Encabezado
+                </label>
               </div>
-
-              <div>
-                <label for="modal-vis-hsize">Tamaño de fuente del encabezado (px)</label>
-                <input
-                  id="modal-vis-hsize"
-                  v-model.number="config.header_font_size"
-                  type="number"
-                  min="14"
-                  max="60"
-                />
+              <div class="colores-seccion__fila">
+                <div class="campo-color">
+                  <label for="vis-h-bg">Fondo</label>
+                  <input
+                    id="vis-h-bg"
+                    v-model="config.header_background_color"
+                    type="color"
+                    class="input-color"
+                  />
+                  <span class="color-hex">{{ config.header_background_color }}</span>
+                </div>
+                <div class="campo-color">
+                  <label for="vis-h-text">Texto</label>
+                  <input
+                    id="vis-h-text"
+                    v-model="config.header_text_color"
+                    type="color"
+                    class="input-color"
+                  />
+                  <span class="color-hex">{{ config.header_text_color }}</span>
+                </div>
               </div>
             </div>
 
-            <div class="m-b-3">
-              <label for="modal-vis-ibt">Título del recuadro de indicadores</label>
-              <input id="modal-vis-ibt" v-model="config.indicator_box_title" type="text" />
-            </div>
-          </section>
-
-          <section class="m-b-4">
-            <h3>Encabezado</h3>
-            <div class="m-b-2">
-              <input id="modal-vis-show-header" v-model="config.show_header" type="checkbox" />
-              <label for="modal-vis-show-header">Mostrar encabezado</label>
-            </div>
-
-            <div class="flex flex-contenido-separado m-b-2">
-              <div>
-                <label for="modal-vis-h-bg">Color de fondo</label>
-                <input id="modal-vis-h-bg" v-model="config.header_background_color" type="color" />
-              </div>
-
-              <div>
-                <label for="modal-vis-h-text">Color de texto</label>
-                <input id="modal-vis-h-text" v-model="config.header_text_color" type="color" />
-              </div>
-            </div>
-          </section>
-
-          <section class="m-b-4">
-            <h3>Contenedores (widgets)</h3>
-            <div class="flex flex-contenido-separado m-b-2">
-              <div>
-                <label for="modal-vis-c-bg">Fondo del widget</label>
-                <input
-                  id="modal-vis-c-bg"
-                  v-model="config.site_interface_background_color"
-                  type="color"
-                />
-              </div>
-
-              <div>
-                <label for="modal-vis-c-text">Texto del widget</label>
-                <input
-                  id="modal-vis-c-text"
-                  v-model="config.site_interface_text_color"
-                  type="color"
-                />
+            <div class="colores-seccion">
+              <div class="colores-seccion__titulo">Contenedores (widgets)</div>
+              <div class="colores-seccion__fila">
+                <div class="campo-color">
+                  <label for="vis-c-bg">Fondo</label>
+                  <input
+                    id="vis-c-bg"
+                    v-model="config.site_interface_background_color"
+                    type="color"
+                    class="input-color"
+                  />
+                  <span class="color-hex">{{ config.site_interface_background_color }}</span>
+                </div>
+                <div class="campo-color">
+                  <label for="vis-c-text">Texto</label>
+                  <input
+                    id="vis-c-text"
+                    v-model="config.site_interface_text_color"
+                    type="color"
+                    class="input-color"
+                  />
+                  <span class="color-hex">{{ config.site_interface_text_color }}</span>
+                </div>
               </div>
             </div>
-          </section>
 
-          <section class="m-b-4">
-            <h3>Pie de página</h3>
-
-            <div class="m-b-2">
-              <input id="modal-vis-show-footer" v-model="config.show_footer" type="checkbox" />
-              <label for="modal-vis-show-footer">Mostrar pie de página</label>
-            </div>
-
-            <div class="flex flex-contenido-separado m-b-2">
-              <div>
-                <label for="modal-vis-f-bg">Color de fondo</label>
-                <input id="modal-vis-f-bg" v-model="config.site_background_color" type="color" />
+            <div class="colores-seccion">
+              <div class="colores-seccion__titulo">
+                <label class="check-inline">
+                  <input v-model="config.show_footer" type="checkbox" />
+                  Pie de página
+                </label>
               </div>
-
-              <div>
-                <label for="modal-vis-f-text">Color de texto</label>
-                <input id="modal-vis-f-text" v-model="config.site_text_color" type="color" />
+              <div class="colores-seccion__fila">
+                <div class="campo-color">
+                  <label for="vis-f-bg">Fondo</label>
+                  <input
+                    id="vis-f-bg"
+                    v-model="config.site_background_color"
+                    type="color"
+                    class="input-color"
+                  />
+                  <span class="color-hex">{{ config.site_background_color }}</span>
+                </div>
+                <div class="campo-color">
+                  <label for="vis-f-text">Texto</label>
+                  <input
+                    id="vis-f-text"
+                    v-model="config.site_text_color"
+                    type="color"
+                    class="input-color"
+                  />
+                  <span class="color-hex">{{ config.site_text_color }}</span>
+                </div>
               </div>
             </div>
-          </section>
+          </div>
 
-          <section class="flex flex-contenido-final">
-            <button type="button" class="boton boton-secundario" @click="modal?.cerrarModal()">
+          <div class="acciones-modal">
+            <button type="button" class="boton boton-secundario" @click="modal?.cerrar()">
               Cancelar
             </button>
             <input
               type="submit"
               class="boton boton-primario"
-              :value="guardando ? 'Guardando...' : 'Guardar'"
+              :value="guardando ? 'Guardando...' : 'Guardar cambios'"
               :disabled="guardando"
             />
-          </section>
+          </div>
         </form>
       </template>
-    </SisdaiModal>
+    </TablerosAdminModalBase>
   </ClientOnly>
 </template>
+
+<style lang="scss" scoped>
+.seccion-titulo {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-texto-secundario, #777);
+  border-bottom: 1px solid var(--color-borde, #e8e8e8);
+  padding-bottom: 4px;
+  margin-bottom: 1rem;
+}
+
+.form-grid-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1rem;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.check-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* Grid de secciones de color (3 columnas) */
+.colores-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.colores-seccion {
+  border: 1px solid var(--color-borde, #e0e0e0);
+  border-radius: 8px;
+  overflow: hidden;
+
+  &__titulo {
+    padding: 8px 12px;
+    background: var(--color-fondo-2, #fafafa);
+    border-bottom: 1px solid var(--color-borde, #e0e0e0);
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  &__fila {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+}
+
+.campo-color {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-borde, #f0f0f0);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  label {
+    font-size: 0.82rem;
+    color: var(--color-texto-secundario, #666);
+    width: 40px;
+    flex-shrink: 0;
+  }
+}
+
+.input-color {
+  width: 40px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid var(--color-borde, #ccc);
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.color-hex {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: var(--color-texto-secundario, #888);
+}
+
+/* Acciones */
+.acciones-modal {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-borde, #e8e8e8);
+}
+</style>

--- a/components/tableros/admin/ModalNuevoIndicador.vue
+++ b/components/tableros/admin/ModalNuevoIndicador.vue
@@ -1,17 +1,14 @@
 <script setup>
-import SisdaiModal from '@centrogeomx/sisdai-componentes/src/componentes/modal/SisdaiModal.vue';
+import { categoriesNamesInSpanish } from '~/utils/consulta';
 
 const props = defineProps({
-  siteId: {
-    type: Number,
-    required: true,
-  },
+  siteId: { type: Number, required: true },
 });
 
 const emit = defineEmits(['creado', 'cerrar']);
 
 const { data: userData } = useAuth();
-const { crearIndicador, fetchDatasets, fetchDatasetAttributes, syncDatasetAttributes } =
+const { crearIndicador, fetchDatasetsPaginados, fetchDatasetAttributes, syncDatasetAttributes } =
   useTableroApi();
 
 const modal = ref(null);
@@ -29,38 +26,92 @@ const formulario = reactive({
   plot_type: 'bar',
   category_method: 'quantile',
   field_category: 5,
-  colors: 'Reds',
+  colors: 'azules_3',
+  reverse_colors: false,
   use_single_field: true,
   is_histogram: false,
 });
 
-// Dataset search
+const CATEGORIAS_CAPAS = Object.entries(categoriesNamesInSpanish).map(([id, label]) => ({
+  id,
+  label,
+}));
+
 const busquedaDataset = ref('');
+const categoriaFiltro = ref('');
 const resultadosDataset = ref([]);
 const buscandoDataset = ref(false);
+const paginaDataset = ref(1);
+const hayMasPaginas = ref(false);
+const cargandoMas = ref(false);
 const datasetSeleccionado = ref(null);
 const atributosDataset = ref([]);
 const cargandoAtributos = ref(false);
 const errorAtributos = ref(false);
 const sincronizandoAtributos = ref(false);
 const errorSincronizacion = ref('');
-const busquedaInputRef = ref(null);
 
 const GEO_ATTRS = new Set(['the_geom', 'geometry', 'geom', 'wkb_geometry', 'shape']);
 
 let busquedaTimeout = null;
 
-function buscarDatasets() {
-  if (busquedaDataset.value.length < 2) {
+async function cargarDatasetsIniciales() {
+  buscandoDataset.value = true;
+  try {
+    const token = userData.value?.accessToken;
+    const data = await fetchDatasetsPaginados('', 1, token, 20, categoriaFiltro.value);
+    resultadosDataset.value = data?.datasets ?? data?.results ?? [];
+    paginaDataset.value = 1;
+    const total = data?.total ?? data?.count ?? 0;
+    hayMasPaginas.value = resultadosDataset.value.length < total;
+  } catch {
     resultadosDataset.value = [];
-    return;
+  } finally {
+    buscandoDataset.value = false;
   }
+}
+
+async function cargarMasDatasets() {
+  cargandoMas.value = true;
+  try {
+    const token = userData.value?.accessToken;
+    const siguientePag = paginaDataset.value + 1;
+    const data = await fetchDatasetsPaginados(
+      busquedaDataset.value,
+      siguientePag,
+      token,
+      20,
+      categoriaFiltro.value
+    );
+    const nuevos = data?.datasets ?? data?.results ?? [];
+    resultadosDataset.value = [...resultadosDataset.value, ...nuevos];
+    paginaDataset.value = siguientePag;
+    const total = data?.total ?? data?.count ?? 0;
+    hayMasPaginas.value = resultadosDataset.value.length < total;
+  } catch {
+    // silently ignore
+  } finally {
+    cargandoMas.value = false;
+  }
+}
+
+function buscarDatasets() {
+  paginaDataset.value = 1;
   if (busquedaTimeout) clearTimeout(busquedaTimeout);
   busquedaTimeout = setTimeout(async () => {
     buscandoDataset.value = true;
     try {
-      const data = await fetchDatasets(busquedaDataset.value);
+      const token = userData.value?.accessToken;
+      const data = await fetchDatasetsPaginados(
+        busquedaDataset.value,
+        1,
+        token,
+        20,
+        categoriaFiltro.value
+      );
       resultadosDataset.value = data?.datasets ?? data?.results ?? [];
+      const total = data?.total ?? data?.count ?? 0;
+      hayMasPaginas.value = resultadosDataset.value.length < total;
     } catch {
       resultadosDataset.value = [];
     } finally {
@@ -68,6 +119,11 @@ function buscarDatasets() {
     }
   }, 350);
 }
+
+watch(categoriaFiltro, () => {
+  busquedaDataset.value = '';
+  cargarDatasetsIniciales();
+});
 
 async function cargarAtributos(pk) {
   cargandoAtributos.value = true;
@@ -135,6 +191,7 @@ async function guardar() {
   error.value = '';
   guardando.value = true;
   try {
+    const colorsValue = formulario.reverse_colors ? `${formulario.colors}_r` : formulario.colors;
     const payload = {
       site: props.siteId,
       group: null,
@@ -148,7 +205,7 @@ async function guardar() {
       plot_type: formulario.plot_type,
       category_method: formulario.category_method,
       field_category: formulario.field_category,
-      colors: formulario.colors,
+      colors: colorsValue,
       use_single_field: formulario.use_single_field,
       is_histogram: formulario.is_histogram,
       stack_order: 1,
@@ -156,7 +213,7 @@ async function guardar() {
     const data = await crearIndicador(payload, userData.value?.accessToken);
     if (data?.id) {
       emit('creado', data);
-      modal.value?.cerrarModal();
+      modal.value?.cerrar();
     } else {
       error.value = data?.detail || JSON.stringify(data);
     }
@@ -176,59 +233,79 @@ function anterior() {
   if (paso.value > 1) paso.value -= 1;
 }
 
-onMounted(() => {
-  modal.value?.abrirModal();
-});
-
 watch(
   () => modal.value,
   (m) => {
-    if (m) m.abrirModal();
-  }
+    if (m) m.abrir();
+  },
+  { once: true }
 );
+
+onMounted(async () => {
+  await cargarDatasetsIniciales();
+});
 </script>
 
 <template>
   <ClientOnly>
-    <SisdaiModal ref="modal" @cerrar="emit('cerrar')">
+    <TablerosAdminModalBase ref="modal" ancho="960px" @cerrar="emit('cerrar')">
       <template #encabezado>
-        <h2>Nuevo indicador — Paso {{ paso }} de 3</h2>
+        <h2>Nuevo indicador</h2>
+        <ol class="pasos-mini" aria-label="Pasos">
+          <li :class="{ activo: paso >= 1, actual: paso === 1 }">1. Datos y capa</li>
+          <li :class="{ activo: paso >= 2, actual: paso === 2 }">2. Tematización</li>
+          <li :class="{ activo: paso >= 3, actual: paso === 3 }">3. Confirmar</li>
+        </ol>
       </template>
 
       <template #cuerpo>
         <form @submit.prevent="siguiente">
-          <section v-show="paso === 1">
-            <h3>Datos del indicador</h3>
-
-            <div class="m-b-2">
-              <label for="ind-name">Nombre del indicador</label>
-              <input id="ind-name" v-model="formulario.name" type="text" required />
-            </div>
-
-            <div class="m-b-2">
-              <label for="ind-info">Descripción</label>
-              <textarea id="ind-info" v-model="formulario.info_text" rows="2" />
-            </div>
-
-            <!-- Dataset search -->
-            <div class="m-b-2">
-              <label>Capa de datos</label>
-              <div v-if="datasetSeleccionado" class="dataset-seleccionado">
-                <span>{{ datasetSeleccionado.title }}</span>
-                <button
-                  type="button"
-                  class="boton boton-chico boton-secundario"
-                  @click="limpiarDataset"
-                >
-                  Cambiar
-                </button>
+          <!-- ── Paso 1: Datos del indicador y capa ── -->
+          <div v-show="paso === 1">
+            <div class="seccion-titulo">Información general</div>
+            <div class="form-grid-2">
+              <div class="campo">
+                <label for="ind-name">Nombre del indicador <span class="requerido">*</span></label>
+                <input id="ind-name" v-model="formulario.name" type="text" required />
               </div>
-              <div v-else class="dataset-buscador">
+              <div class="campo">
+                <label for="ind-info">Descripción</label>
+                <input id="ind-info" v-model="formulario.info_text" type="text" />
+              </div>
+            </div>
+
+            <div class="seccion-titulo m-t-3">Capa de datos</div>
+
+            <div v-if="datasetSeleccionado" class="dataset-seleccionado">
+              <div class="dataset-seleccionado__info">
+                <strong>{{ datasetSeleccionado.title }}</strong>
+                <span v-if="datasetSeleccionado.alternate" class="formulario-ayuda monospace">
+                  {{ datasetSeleccionado.alternate }}
+                </span>
+              </div>
+              <button
+                type="button"
+                class="boton boton-chico boton-secundario"
+                @click="limpiarDataset"
+              >
+                Cambiar
+              </button>
+            </div>
+
+            <div v-else>
+              <div class="dataset-filtros m-b-1">
+                <select v-model="categoriaFiltro" title="Filtrar por categoría">
+                  <option value="">Todas las categorías</option>
+                  <option v-for="cat in CATEGORIAS_CAPAS" :key="cat.id" :value="cat.id">
+                    {{ cat.label }}
+                  </option>
+                </select>
+              </div>
+              <div class="dataset-buscador">
                 <input
-                  ref="busquedaInputRef"
                   v-model="busquedaDataset"
                   type="text"
-                  placeholder="Escribe para buscar capa..."
+                  placeholder="Buscar por nombre..."
                   autocomplete="off"
                   @input="buscarDatasets"
                   @keydown.enter.prevent
@@ -236,7 +313,7 @@ watch(
                   @keyup.stop
                   @keypress.stop
                 />
-                <p v-show="buscandoDataset" class="formulario-ayuda">Buscando...</p>
+                <p v-show="buscandoDataset" class="formulario-ayuda">Cargando capas...</p>
                 <ul
                   v-show="!buscandoDataset && resultadosDataset.length > 0"
                   class="dataset-resultados"
@@ -246,16 +323,21 @@ watch(
                     :key="ds.pk"
                     @mousedown.prevent="seleccionarDataset(ds)"
                   >
-                    {{ ds.title }}
-                    <span class="formulario-ayuda">ID: {{ ds.pk }}</span>
+                    <span class="fw-500">{{ ds.title }}</span>
+                    <span v-if="ds.alternate" class="formulario-ayuda monospace">{{
+                      ds.alternate
+                    }}</span>
+                  </li>
+                  <li
+                    v-if="hayMasPaginas"
+                    class="dataset-resultados__mas"
+                    @mousedown.prevent="cargarMasDatasets"
+                  >
+                    {{ cargandoMas ? 'Cargando...' : 'Mostrar más capas...' }}
                   </li>
                 </ul>
                 <p
-                  v-show="
-                    !buscandoDataset &&
-                    resultadosDataset.length === 0 &&
-                    busquedaDataset.length >= 2
-                  "
+                  v-show="!buscandoDataset && resultadosDataset.length === 0"
                   class="formulario-ayuda"
                 >
                   Sin resultados.
@@ -263,9 +345,8 @@ watch(
               </div>
             </div>
 
-            <!-- Field pickers (available once a dataset is selected) -->
             <template v-if="datasetSeleccionado">
-              <p v-if="errorAtributos" class="formulario-ayuda color-error">
+              <p v-if="errorAtributos" class="formulario-ayuda color-error m-t-2">
                 No se pudieron cargar los campos del dataset.
               </p>
 
@@ -274,8 +355,8 @@ watch(
                 class="sin-atributos-aviso"
               >
                 <p class="formulario-ayuda">
-                  Este recurso no tiene atributos registrados. Puedes sincronizarlos directamente
-                  desde el servicio de origen.
+                  Este recurso no tiene atributos registrados. Puedes sincronizarlos desde el
+                  servicio de origen.
                 </p>
                 <button
                   type="button"
@@ -285,196 +366,325 @@ watch(
                 >
                   {{ sincronizandoAtributos ? 'Sincronizando...' : 'Sincronizar atributos' }}
                 </button>
-                <p v-if="errorSincronizacion" class="formulario-ayuda color-error m-t-1">
+                <p v-if="errorSincronizacion" class="formulario-ayuda color-error">
                   {{ errorSincronizacion }}
                 </p>
               </div>
 
-              <div class="m-b-2">
-                <label for="ind-field-id">Campo ID de la geometría</label>
-                <select
-                  id="ind-field-id"
-                  v-model="formulario.layer_id_field"
-                  :disabled="cargandoAtributos || !atributosDataset.length"
-                  required
-                >
-                  <option value="" disabled>
-                    {{
-                      cargandoAtributos
-                        ? 'Cargando campos...'
-                        : !atributosDataset.length
-                          ? 'Sin atributos disponibles'
-                          : 'Selecciona un campo'
-                    }}
-                  </option>
-                  <option v-for="a in atributosDataset" :key="a.attribute" :value="a.attribute">
-                    {{ a.attribute }}
-                  </option>
-                </select>
-              </div>
-
-              <div class="m-b-2">
-                <label for="ind-field-one">Campo principal a visualizar</label>
-                <select
-                  id="ind-field-one"
-                  v-model="formulario.field_one"
-                  :disabled="cargandoAtributos || !atributosDataset.length"
-                  required
-                >
-                  <option value="" disabled>
-                    {{
-                      cargandoAtributos
-                        ? 'Cargando campos...'
-                        : !atributosDataset.length
-                          ? 'Sin atributos disponibles'
-                          : 'Selecciona un campo'
-                    }}
-                  </option>
-                  <option v-for="a in atributosDataset" :key="a.attribute" :value="a.attribute">
-                    {{ a.attribute }} ({{ a.attribute_type }})
-                  </option>
-                </select>
-              </div>
-
-              <div class="m-b-2">
-                <label for="ind-field-two">Campo secundario (opcional)</label>
-                <select
-                  id="ind-field-two"
-                  v-model="formulario.field_two"
-                  :disabled="cargandoAtributos || !atributosDataset.length"
-                >
-                  <option value="">— ninguno —</option>
-                  <option v-for="a in atributosDataset" :key="a.attribute" :value="a.attribute">
-                    {{ a.attribute }} ({{ a.attribute_type }})
-                  </option>
-                </select>
+              <div class="seccion-titulo m-t-3">Campos</div>
+              <div class="form-grid-3">
+                <div class="campo">
+                  <label for="ind-field-id"
+                    >Campo ID de geometría <span class="requerido">*</span></label
+                  >
+                  <select
+                    id="ind-field-id"
+                    v-model="formulario.layer_id_field"
+                    :disabled="cargandoAtributos || !atributosDataset.length"
+                    required
+                  >
+                    <option value="" disabled>
+                      {{
+                        cargandoAtributos
+                          ? 'Cargando...'
+                          : !atributosDataset.length
+                            ? 'Sin atributos'
+                            : 'Selecciona'
+                      }}
+                    </option>
+                    <option v-for="a in atributosDataset" :key="a.attribute" :value="a.attribute">
+                      {{ a.attribute }}
+                    </option>
+                  </select>
+                </div>
+                <div class="campo">
+                  <label for="ind-field-one"
+                    >Campo principal <span class="requerido">*</span></label
+                  >
+                  <select
+                    id="ind-field-one"
+                    v-model="formulario.field_one"
+                    :disabled="cargandoAtributos || !atributosDataset.length"
+                    required
+                  >
+                    <option value="" disabled>
+                      {{
+                        cargandoAtributos
+                          ? 'Cargando...'
+                          : !atributosDataset.length
+                            ? 'Sin atributos'
+                            : 'Selecciona'
+                      }}
+                    </option>
+                    <option v-for="a in atributosDataset" :key="a.attribute" :value="a.attribute">
+                      {{ a.attribute }}
+                      <span v-if="a.attribute_type">({{ a.attribute_type }})</span>
+                    </option>
+                  </select>
+                </div>
+                <div class="campo">
+                  <label for="ind-field-two">Campo secundario</label>
+                  <select
+                    id="ind-field-two"
+                    v-model="formulario.field_two"
+                    :disabled="cargandoAtributos || !atributosDataset.length"
+                  >
+                    <option value="">— ninguno —</option>
+                    <option v-for="a in atributosDataset" :key="a.attribute" :value="a.attribute">
+                      {{ a.attribute }}
+                      <span v-if="a.attribute_type">({{ a.attribute_type }})</span>
+                    </option>
+                  </select>
+                </div>
               </div>
             </template>
-          </section>
+          </div>
 
-          <section v-show="paso === 2">
-            <h3>Tematización</h3>
-
-            <div class="m-b-2">
-              <label for="ind-method">Método de clasificación</label>
-              <select id="ind-method" v-model="formulario.category_method">
-                <option value="quantile">Cuantiles</option>
-                <option value="jenks">Jenks (natural breaks)</option>
-                <option value="equal">Intervalos iguales</option>
-                <option value="manual">Manual</option>
-              </select>
+          <!-- ── Paso 2: Tematización ── -->
+          <div v-show="paso === 2">
+            <div class="seccion-titulo">Clasificación</div>
+            <div class="form-grid-2">
+              <div class="campo">
+                <label for="ind-method">Método</label>
+                <select id="ind-method" v-model="formulario.category_method">
+                  <option value="quantile">Cuantiles</option>
+                  <option value="jenks">Jenks (natural breaks)</option>
+                  <option value="equal">Intervalos iguales</option>
+                  <option value="manual">Manual</option>
+                </select>
+              </div>
+              <div class="campo">
+                <label for="ind-categories">Número de clases</label>
+                <input
+                  id="ind-categories"
+                  v-model.number="formulario.field_category"
+                  type="number"
+                  min="2"
+                  max="10"
+                />
+              </div>
             </div>
 
-            <div class="m-b-2">
-              <label for="ind-categories">Número de clases</label>
-              <input
-                id="ind-categories"
-                v-model.number="formulario.field_category"
-                type="number"
-                min="2"
-                max="10"
-              />
+            <div class="seccion-titulo m-t-3">Visualización</div>
+            <div class="form-grid-2">
+              <div class="campo">
+                <label for="ind-colors">Rampa de color</label>
+                <select id="ind-colors" v-model="formulario.colors">
+                  <option value="azules_3">Azules</option>
+                  <option value="cafes">Cafés</option>
+                  <option value="morados">Morados</option>
+                  <option value="verdes_2">Verdes</option>
+                  <option value="naranjas">Naranjas</option>
+                  <option value="rosas">Rosas</option>
+                  <option value="varios">Multicolor</option>
+                  <option value="semaforo">Semáforo</option>
+                  <option value="semaforo_3">Semáforo 3 tonos</option>
+                </select>
+                <label class="check-inline m-t-1">
+                  <input v-model="formulario.reverse_colors" type="checkbox" />
+                  Invertir paleta
+                </label>
+              </div>
+              <div class="campo">
+                <label for="ind-plot-type">Tipo de gráfica</label>
+                <select id="ind-plot-type" v-model="formulario.plot_type">
+                  <optgroup label="Barras">
+                    <option value="bar">Barras verticales</option>
+                    <option value="horizontal_bar">Barras horizontales</option>
+                    <option value="histogram">Histograma</option>
+                  </optgroup>
+                  <optgroup label="Circular">
+                    <option value="donut">Dona</option>
+                    <option value="pie">Pastel (pie)</option>
+                  </optgroup>
+                  <optgroup label="Líneas y área">
+                    <option value="line">Línea</option>
+                    <option value="area">Área</option>
+                  </optgroup>
+                  <optgroup label="Otros">
+                    <option value="scatter">Dispersión</option>
+                    <option value="gauge">Gauge</option>
+                    <option value="radar">Radar</option>
+                    <option value="treemap">Mapa de árbol</option>
+                  </optgroup>
+                </select>
+              </div>
             </div>
+          </div>
 
-            <div class="m-b-2">
-              <label for="ind-colors">Rampa de color</label>
-              <select id="ind-colors" v-model="formulario.colors">
-                <option value="Reds">Rojos</option>
-                <option value="Blues">Azules</option>
-                <option value="Greens">Verdes</option>
-                <option value="Oranges">Naranjas</option>
-                <option value="Purples">Morados</option>
-                <option value="Greys">Grises</option>
-                <option value="YlOrRd">Amarillo → Rojo</option>
-                <option value="BuPu">Azul → Morado</option>
-              </select>
-            </div>
-
-            <div class="m-b-2">
-              <label for="ind-plot-type">Tipo de gráfica</label>
-              <select id="ind-plot-type" v-model="formulario.plot_type">
-                <option value="bar">Barras</option>
-                <option value="histogram">Histograma</option>
-              </select>
-            </div>
-          </section>
-
-          <section v-show="paso === 3">
-            <h3>Confirmar</h3>
-            <p>
-              Se creará el indicador con los parámetros definidos. Los datos de gráfica y mapa
-              podrán reconstruirse después desde la edición del indicador.
+          <!-- ── Paso 3: Confirmar ── -->
+          <div v-show="paso === 3">
+            <div class="seccion-titulo">Resumen del indicador</div>
+            <dl class="resumen-dl">
+              <div class="resumen-dl__fila">
+                <dt>Nombre</dt>
+                <dd>{{ formulario.name }}</dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Capa</dt>
+                <dd>{{ datasetSeleccionado?.title || formulario.layer }}</dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Campo ID</dt>
+                <dd>{{ formulario.layer_id_field }}</dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Campo principal</dt>
+                <dd>{{ formulario.field_one }}</dd>
+              </div>
+              <div v-if="formulario.field_two" class="resumen-dl__fila">
+                <dt>Campo secundario</dt>
+                <dd>{{ formulario.field_two }}</dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Método</dt>
+                <dd>{{ formulario.category_method }}</dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Clases</dt>
+                <dd>{{ formulario.field_category }}</dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Colores</dt>
+                <dd>
+                  {{ formulario.colors }}{{ formulario.reverse_colors ? ' (invertida)' : '' }}
+                </dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Gráfica</dt>
+                <dd>{{ formulario.plot_type }}</dd>
+              </div>
+            </dl>
+            <p class="formulario-ayuda m-t-2">
+              Los datos de gráfica y mapa se podrán reconstruir desde la edición del indicador.
             </p>
+          </div>
 
-            <ul>
-              <li><b>Nombre:</b> {{ formulario.name }}</li>
-              <li><b>Capa:</b> {{ datasetSeleccionado?.title || formulario.layer }}</li>
-              <li><b>Campo ID:</b> {{ formulario.layer_id_field }}</li>
-              <li><b>Campo 1:</b> {{ formulario.field_one }}</li>
-              <li><b>Método:</b> {{ formulario.category_method }}</li>
-              <li><b>Clases:</b> {{ formulario.field_category }}</li>
-              <li><b>Colores:</b> {{ formulario.colors }}</li>
-            </ul>
-          </section>
+          <p v-if="error" class="color-error m-t-2">{{ error }}</p>
 
-          <p v-if="error" class="color-error">{{ error }}</p>
-
-          <div class="flex flex-contenido-separado">
-            <div>
+          <div class="acciones-modal">
+            <div class="acciones-modal__izq">
               <button
                 v-if="paso > 1"
                 type="button"
                 class="boton boton-secundario"
                 @click="anterior"
               >
-                Atrás
+                ← Atrás
               </button>
               <button type="button" class="boton boton-secundario" @click="emit('cerrar')">
                 Cancelar
               </button>
             </div>
-
             <input
               type="submit"
               class="boton boton-primario"
-              :value="paso < 3 ? 'Siguiente' : guardando ? 'Guardando...' : 'Crear indicador'"
+              :value="paso < 3 ? 'Siguiente →' : guardando ? 'Guardando...' : 'Crear indicador'"
               :disabled="guardando"
             />
           </div>
         </form>
       </template>
-    </SisdaiModal>
+    </TablerosAdminModalBase>
   </ClientOnly>
 </template>
 
 <style lang="scss" scoped>
-.dataset-seleccionado {
+/* Indicador de pasos */
+.pasos-mini {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 6px 10px;
-  border: 1px solid var(--color-borde, #ccc);
-  border-radius: 4px;
-  background: var(--color-fondo-2, #f5f5f5);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0;
+
+  li {
+    font-size: 0.78rem;
+    padding: 2px 12px;
+    border-radius: 12px;
+    color: var(--color-texto-secundario, #999);
+    white-space: nowrap;
+
+    &.activo {
+      color: var(--color-secundario-8, #5f3e47);
+    }
+    &.actual {
+      background: var(--color-secundario-3, #f8e1e8);
+      color: var(--color-primario-4, #991f47);
+      font-weight: 600;
+    }
+  }
 }
 
-.dataset-buscador {
-  position: relative;
+/* Secciones */
+.seccion-titulo {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-texto-secundario, #777);
+  border-bottom: 1px solid var(--color-borde, #e8e8e8);
+  padding-bottom: 4px;
+  margin-bottom: 1rem;
+}
 
-  input {
+/* Grillas */
+.form-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.form-grid-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1rem;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.check-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+/* Dataset */
+.dataset-seleccionado {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 8px 12px;
+  border: 1px solid var(--color-borde, #ccc);
+  border-radius: 6px;
+  background: var(--color-secundario-2, #fcf3f5);
+  margin-bottom: 0.5rem;
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+}
+
+.dataset-filtros {
+  select {
     width: 100%;
   }
 }
 
-.sin-atributos-aviso {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 10px 12px;
-  border: 1px dashed var(--color-borde, #ccc);
-  border-radius: 4px;
-  background: var(--color-fondo-2, #f5f5f5);
-  margin-bottom: 1rem;
+.dataset-buscador {
+  position: relative;
+  input {
+    width: 100%;
+  }
 }
 
 .dataset-resultados {
@@ -488,9 +698,10 @@ watch(
   margin: 0;
   background: #fff;
   border: 1px solid var(--color-borde, #ccc);
-  border-radius: 4px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
-  max-height: 220px;
+  border-top: none;
+  border-radius: 0 0 6px 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  max-height: 200px;
   overflow-y: auto;
 
   li {
@@ -499,10 +710,97 @@ watch(
     display: flex;
     flex-direction: column;
     gap: 2px;
+    font-size: 0.9rem;
 
     &:hover {
-      background: var(--color-primario-suave, #f0e4e8);
+      background: var(--color-secundario-2, #fcf3f5);
     }
   }
+
+  &__mas {
+    justify-content: center;
+    align-items: center;
+    font-size: 0.82rem;
+    color: var(--color-primario-4, #991f47);
+    font-weight: 600;
+    border-top: 1px solid var(--color-borde, #eee);
+    cursor: pointer;
+
+    &:hover {
+      background: var(--color-fondo-2, #f5f5f5) !important;
+    }
+  }
+}
+
+.sin-atributos-aviso {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 10px 12px;
+  border: 1px dashed var(--color-borde, #ccc);
+  border-radius: 6px;
+  background: var(--color-fondo-2, #f5f5f5);
+  margin-top: 0.75rem;
+}
+
+/* Resumen */
+.resumen-dl {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--color-borde, #e0e0e0);
+  border-radius: 6px;
+  overflow: hidden;
+
+  &__fila {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 0;
+    border-bottom: 1px solid var(--color-borde, #e8e8e8);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    dt {
+      padding: 7px 12px;
+      background: var(--color-fondo-2, #f5f5f5);
+      font-weight: 600;
+      font-size: 0.85rem;
+      color: var(--color-texto-secundario, #666);
+    }
+
+    dd {
+      padding: 7px 12px;
+      margin: 0;
+      font-size: 0.9rem;
+    }
+  }
+}
+
+/* Acciones */
+.acciones-modal {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-borde, #e8e8e8);
+
+  &__izq {
+    display: flex;
+    gap: 0.5rem;
+  }
+}
+
+.requerido {
+  color: var(--color-primario-4, #991f47);
+}
+.fw-500 {
+  font-weight: 500;
+}
+.monospace {
+  font-family: monospace;
+  font-size: 0.78rem;
 }
 </style>

--- a/pages/ia/proyecto/[id]/configurar.vue
+++ b/pages/ia/proyecto/[id]/configurar.vue
@@ -31,6 +31,7 @@ const campoBusqueda = ref('');
 
 const agregaCatalogoModal = ref(null);
 const seleccionCatalogoModal = ref(null);
+/* eslint-disable no-unused-vars */
 const dictTipoRecurso = {
   dataLayer: 'capas',
   dataTable: 'tablas',
@@ -264,6 +265,7 @@ function cargarArchivosGeonode() {
   archivosGeonode.value = [...archivosGeonode.value, ...nuevosArchivos];
   archivosTabla.value = [...archivosSeleccionados.value, ...archivosGeonode.value];
 }
+/* eslint-enable no-unused-vars */
 
 // Método para manejar la selección de archivos
 const manejarSeleccionArchivos = (event) => {
@@ -537,7 +539,7 @@ onBeforeUnmount(() => {
                   @change="manejarSeleccionArchivos"
                 />
                 <p class="m-y-1 texto-derecha">
-                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                  <small><b>Solo archivos PDF, CSV y Word.</b></small>
                 </p>
               </div>
             </div>

--- a/pages/ia/proyectos/crear-nuevo.vue
+++ b/pages/ia/proyectos/crear-nuevo.vue
@@ -29,6 +29,8 @@ const campoBusqueda = ref('');
 
 const agregaCatalogoModal = ref(null);
 const seleccionCatalogoModal = ref(null);
+
+/* eslint-disable no-unused-vars */
 const dictTipoRecurso = {
   dataLayer: 'capas',
   dataTable: 'tablas',
@@ -128,6 +130,7 @@ async function fetchNewData() {
 }
 
 // Selecciona la categoría en el modal de fuentes de catálogo
+
 async function seleccionarCategoria(categoria) {
   if (categoriaSeleccionada.value !== categoriesDict.value[categoria].label) {
     // reseteando recursos filtrados por categoría y valores
@@ -159,6 +162,7 @@ function removerBusquedaFiltro() {
 }
 
 // Método para buscar el recurso con filtro el modal de fuentes de catálogo
+
 async function buscarRecurso() {
   if (categoriaSeleccionada.value !== null) {
     // reseteando recursos filtrados por categoría y valores
@@ -184,6 +188,7 @@ async function buscarRecurso() {
 }
 
 // Remueve la búsqueda en el filtro del modal de fuentes de catálogo
+
 async function removerBusqueda() {
   storeFilters.updateFilter('inputSearch', '');
   if (categoriaSeleccionada.value !== null && inputSearch.value === '') {
@@ -215,6 +220,7 @@ function agregarFuentesCatalogo() {
 }
 
 // Abre el modal para agregar fuentes del catálogo
+
 async function siguenteAgregar() {
   agregaCatalogoModal.value.cerrarModal();
   seleccionCatalogoModal.value.abrirModal();
@@ -246,6 +252,7 @@ function seleccionarProyecto(proyecto) {
 }
 
 // Método para manejar los archivos seleccionados del catálogo de geonode
+
 function cargarArchivosGeonode() {
   seleccionCatalogoModal?.value.cerrarModal();
   // se obtiene primero del geonode
@@ -262,6 +269,7 @@ function cargarArchivosGeonode() {
   archivosGeonode.value = [...archivosGeonode.value, ...nuevosArchivos];
   archivosTabla.value = [...archivosSeleccionados.value, ...archivosGeonode.value];
 }
+/* eslint-enable no-unused-vars */
 
 // Método para manejar la selección de archivos
 const manejarSeleccionArchivos = (event) => {
@@ -490,7 +498,7 @@ onMounted(() => {
                   @change="manejarSeleccionArchivos"
                 />
                 <p class="m-y-1 texto-derecha">
-                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                  <small><b>Solo archivos PDF, CSV y Word.</b></small>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Resumen

- Crea `ModalBase.vue` como componente base con `<dialog>` nativo (sin dependencia de SisdaiModal)
- Migra `FormularioIndicador`, `FormularioCuadroDatos` y `ModalIdentidadVisual` al nuevo ModalBase
- Corrige la apertura de `ModalNuevoIndicador` usando `watch` en lugar de `onMounted` para manejar el timing de `<ClientOnly>`
- Corrige la visibilidad del botón de editar subgrupo en `ArbolGrupo` cambiando `<header>` HTML por `<div>` con clase propia

## Plan de prueba

- [ ] Abrir el editor de un tablero y verificar que los modales de Indicador, Cuadro de datos e Identidad visual abren correctamente
- [ ] Verificar que el modal de Nuevo Indicador abre al hacer clic en el botón
- [ ] En la pestaña Estructura del sitio, verificar que aparece el botón "Editar" en los subgrupos
- [ ] Confirmar que los modales se cierran con Cancelar y con la X