### PR TITLE
feat(tableros): requerir autenticación en páginas de tableros

### DIFF
--- a/pages/geocontenidos/tableros/[sitio]/index.vue
+++ b/pages/geocontenidos/tableros/[sitio]/index.vue
@@ -1,8 +1,14 @@
 <script setup>
 import SisdaiModal from '@centrogeomx/sisdai-componentes/src/componentes/modal/SisdaiModal.vue';
 
-const { data: userData } = useAuth();
+const { data: userData, status, signIn } = useAuth();
 const route = useRoute();
+
+const noAutenticado = computed(() => status.value === 'unauthenticated');
+
+function iniciarSesion() {
+  signIn('keycloak', { callbackUrl: route.fullPath });
+}
 const { fetchSitio, crearSitio, actualizarSitio, togglePublic } = useTableroApi();
 
 const idRuta = computed(() => route.params.sitio);
@@ -23,7 +29,7 @@ const sitio = reactive({
   url: '',
   title: '',
   info_text: '',
-  is_public: true,
+  is_public: false,
 });
 
 const togglandoPublico = ref(false);
@@ -58,7 +64,7 @@ async function cargarSitio() {
       sitio.url = datos.url || '';
       sitio.title = datos.title || '';
       sitio.info_text = datos.info_text || '';
-      sitio.is_public = datos.is_public ?? true;
+      sitio.is_public = datos.is_public ?? false;
     }
   } catch (e) {
     console.error('Error al cargar sitio:', e);
@@ -83,6 +89,7 @@ async function guardar() {
     url: sitio.url,
     title: sitio.title,
     info_text: sitio.info_text,
+    ...(esNuevo.value ? { is_public: false } : {}),
   };
 
   try {
@@ -123,80 +130,130 @@ cargarSitio();
 
 <template>
   <section>
-    <GeocontenidosTituloVolver
-      :titulo="esNuevo ? 'Nuevo tablero' : `Editar tablero: ${sitio.name}`"
-      volver="/tableros"
-    />
-
-    <div v-if="!esNuevo && sitio.id" class="flex brecha-2 m-b-3">
-      <NuxtLink
-        :to="`/tableros/${sitio.id}`"
-        class="boton boton-secundario boton-chico"
-        target="_blank"
-      >
-        <span class="pictograma-visualizar m-r-1" />
-        Ver tablero
-      </NuxtLink>
-
-      <button
-        type="button"
-        class="boton boton-chico"
-        :class="sitio.is_public ? 'boton-secundario' : 'boton-primario'"
-        :disabled="togglandoPublico"
-        @click="togglearPublico"
-      >
-        <span
-          :class="sitio.is_public ? 'pictograma-ojo' : 'pictograma-ojo-cerrado'"
-          class="m-r-1"
-        />
-        {{
-          togglandoPublico
-            ? 'Cambiando...'
-            : sitio.is_public
-              ? 'Público — hacer privado'
-              : 'Privado — hacer público'
-        }}
+    <!-- Sesión requerida -->
+    <div v-if="noAutenticado" class="sesion-requerida">
+      <span class="pictograma-candado sesion-requerida__icono" aria-hidden="true" />
+      <h2 class="sesion-requerida__titulo">Acceso restringido</h2>
+      <p class="sesion-requerida__desc">
+        Para editar este tablero necesitas iniciar sesión con tu cuenta institucional.
+      </p>
+      <button type="button" class="boton boton-primario" @click="iniciarSesion">
+        Iniciar sesión
       </button>
     </div>
 
-    <GeocontenidosLoader v-if="cargandoSitio" mensaje="Cargando tablero..." />
+    <template v-else>
+      <GeocontenidosTituloVolver
+        :titulo="esNuevo ? 'Nuevo tablero' : `Editar tablero: ${sitio.name}`"
+        volver="/tableros"
+      />
 
-    <GeocontenidosPestanias v-else :pestanias="pestanias" id-seleccion="identidad">
-      <template #contenido-identidad>
-        <TablerosAdminTabIdentidad :sitio="sitio" @actualizar="aplicarCambios" @guardar="guardar" />
-      </template>
+      <div v-if="!esNuevo && sitio.id" class="flex brecha-2 m-b-3">
+        <NuxtLink
+          :to="`/tableros/${sitio.id}`"
+          class="boton boton-secundario boton-chico"
+          target="_blank"
+        >
+          <span class="pictograma-visualizar m-r-1" />
+          Ver tablero
+        </NuxtLink>
 
-      <template #contenido-estructura>
-        <TablerosAdminTabEstructura v-if="sitio.id" :site-id="sitio.id" />
-      </template>
-
-      <template #contenido-datos>
-        <TablerosAdminTabDatos v-if="sitio.id" :site-id="sitio.id" />
-      </template>
-    </GeocontenidosPestanias>
-
-    <ClientOnly>
-      <SisdaiModal ref="modalStatus">
-        <template #encabezado>
-          <span v-if="estatusAlGuardar.cargando" />
-          <h2 v-else>
-            {{ estatusAlGuardar.estado ? 'Guardado con éxito' : 'Error al guardar' }}
-          </h2>
-        </template>
-
-        <template #cuerpo>
-          <GeocontenidosLoader
-            v-if="estatusAlGuardar.cargando"
-            :mensaje="estatusAlGuardar.textoCargando"
+        <button
+          type="button"
+          class="boton boton-chico"
+          :class="sitio.is_public ? 'boton-secundario' : 'boton-primario'"
+          :disabled="togglandoPublico"
+          @click="togglearPublico"
+        >
+          <span
+            :class="sitio.is_public ? 'pictograma-ojo' : 'pictograma-ojo-cerrado'"
+            class="m-r-1"
           />
+          {{
+            togglandoPublico
+              ? 'Cambiando...'
+              : sitio.is_public
+                ? 'Público — hacer privado'
+                : 'Privado — hacer público'
+          }}
+        </button>
+      </div>
 
-          <p v-else-if="estatusAlGuardar.estado === false" v-text="estatusAlGuardar.mensaje" />
+      <GeocontenidosLoader v-if="cargandoSitio" mensaje="Cargando tablero..." />
 
-          <p v-else class="texto-centrado">
-            <span class="pictograma-aprobado pictograma-grande" />
-          </p>
+      <GeocontenidosPestanias v-else :pestanias="pestanias" id-seleccion="identidad">
+        <template #contenido-identidad>
+          <TablerosAdminTabIdentidad
+            :sitio="sitio"
+            @actualizar="aplicarCambios"
+            @guardar="guardar"
+          />
         </template>
-      </SisdaiModal>
-    </ClientOnly>
+
+        <template #contenido-estructura>
+          <TablerosAdminTabEstructura v-if="sitio.id" :site-id="sitio.id" />
+        </template>
+
+        <template #contenido-datos>
+          <TablerosAdminTabDatos v-if="sitio.id" :site-id="sitio.id" />
+        </template>
+      </GeocontenidosPestanias>
+
+      <ClientOnly>
+        <SisdaiModal ref="modalStatus">
+          <template #encabezado>
+            <span v-if="estatusAlGuardar.cargando" />
+            <h2 v-else>
+              {{ estatusAlGuardar.estado ? 'Guardado con éxito' : 'Error al guardar' }}
+            </h2>
+          </template>
+
+          <template #cuerpo>
+            <GeocontenidosLoader
+              v-if="estatusAlGuardar.cargando"
+              :mensaje="estatusAlGuardar.textoCargando"
+            />
+
+            <p v-else-if="estatusAlGuardar.estado === false" v-text="estatusAlGuardar.mensaje" />
+
+            <p v-else class="texto-centrado">
+              <span class="pictograma-aprobado pictograma-grande" />
+            </p>
+          </template>
+        </SisdaiModal>
+      </ClientOnly> </template
+    ><!-- /v-else autenticado -->
   </section>
 </template>
+
+<style lang="scss" scoped>
+.sesion-requerida {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 4rem 2rem;
+  text-align: center;
+
+  &__icono {
+    font-size: 3rem;
+    color: var(--color-secundario-7, #876670);
+    opacity: 0.6;
+  }
+
+  &__titulo {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--color-primario-4, #991f47);
+    margin: 0;
+  }
+
+  &__desc {
+    font-size: 1rem;
+    color: var(--color-texto-secundario, #555);
+    max-width: 420px;
+    margin: 0;
+  }
+}
+</style>

--- a/pages/geocontenidos/tableros/index.vue
+++ b/pages/geocontenidos/tableros/index.vue
@@ -1,8 +1,13 @@
 <script setup>
-const { status, data: userData } = useAuth();
+const { status, signIn, data: userData } = useAuth();
 const { fetchSitios, eliminarSitio, togglePublic } = useTableroApi();
 
 const estaLogueado = computed(() => status.value === 'authenticated');
+const noAutenticado = computed(() => status.value === 'unauthenticated');
+
+function iniciarSesion() {
+  signIn('keycloak', { callbackUrl: '/geocontenidos/tableros' });
+}
 
 const sitios = ref([]);
 const estaCargando = ref(false);
@@ -50,105 +55,152 @@ function formatearFecha(fecha) {
   });
 }
 
-cargarSitios();
+if (estaLogueado.value) cargarSitios();
+watch(estaLogueado, (v) => {
+  if (v) cargarSitios();
+});
 </script>
 
 <template>
   <div>
-    <div>
-      <h2>Bienvenido a Tableros</h2>
-
-      <p
-        class="fondo-color-acento borde-redondeado-8 borde-l borde-grosor-4 p-4"
-        style="border-color: var(--color-primario-4)"
-      >
-        Los Tableros de datos son sitios interactivos donde se presentan indicadores temáticos con
-        mapas, gráficas y tarjetas de resumen, organizados en grupos y subgrupos.
+    <!-- Sesión requerida -->
+    <div v-if="noAutenticado" class="sesion-requerida">
+      <span class="pictograma-candado sesion-requerida__icono" aria-hidden="true" />
+      <h2 class="sesion-requerida__titulo">Acceso restringido</h2>
+      <p class="sesion-requerida__desc">
+        Para ver y gestionar tus tableros necesitas iniciar sesión con tu cuenta institucional.
       </p>
-
-      <div v-if="estaLogueado" class="flex brecha-2 m-b-4">
-        <NuxtLink to="/geocontenidos/tableros/nuevo" class="boton boton-primario">
-          <span class="pictograma-agregar m-r-1" />
-          Crear Tablero
-        </NuxtLink>
-        <NuxtLink to="/geocontenidos/importar-datos" class="boton boton-secundario">
-          <span class="pictograma-archivo-subir m-r-1" />
-          Desde mis datos
-        </NuxtLink>
-      </div>
+      <button type="button" class="boton boton-primario" @click="iniciarSesion">
+        Iniciar sesión
+      </button>
     </div>
 
-    <GeocontenidosLoader v-if="estaCargando" />
+    <template v-else>
+      <div>
+        <h2>Bienvenido a Tableros</h2>
 
-    <div v-else-if="sitios.length > 0" class="grid reticula-12">
-      <div v-for="sitio in sitios" :key="sitio.id" class="columna-8 columna-4-esc">
-        <div class="tarjeta">
-          <div class="tarjeta-cuerpo">
-            <p class="tarjeta-titulo">{{ sitio.name }}</p>
+        <p
+          class="fondo-color-acento borde-redondeado-8 borde-l borde-grosor-4 p-4"
+          style="border-color: var(--color-primario-4)"
+        >
+          Los Tableros de datos son sitios interactivos donde se presentan indicadores temáticos con
+          mapas, gráficas y tarjetas de resumen, organizados en grupos y subgrupos.
+        </p>
 
-            <p v-if="sitio.subtitle" class="tarjeta-etiqueta">{{ sitio.subtitle }}</p>
+        <div v-if="estaLogueado" class="flex brecha-2 m-b-4">
+          <NuxtLink to="/geocontenidos/tableros/nuevo" class="boton boton-primario">
+            <span class="pictograma-agregar m-r-1" />
+            Crear Tablero
+          </NuxtLink>
+          <NuxtLink to="/geocontenidos/importar-datos" class="boton boton-secundario">
+            <span class="pictograma-archivo-subir m-r-1" />
+            Desde mis datos
+          </NuxtLink>
+        </div>
+      </div>
 
-            <p class="tarjeta-etiqueta">Creado: {{ formatearFecha(sitio.created) }}</p>
-          </div>
+      <GeocontenidosLoader v-if="estaCargando" />
 
-          <div class="tarjeta-pie flex">
-            <NuxtLink
-              class="boton boton-chico boton-secundario"
-              :to="`/tableros/${sitio.id}`"
-              target="_blank"
-              title="Previsualizar tablero"
-            >
-              <span class="pictograma-ojo-ver m-r-1" />
-              Previsualizar
-            </NuxtLink>
+      <div v-else-if="sitios.length > 0" class="grid reticula-12">
+        <div v-for="sitio in sitios" :key="sitio.id" class="columna-8 columna-4-esc">
+          <div class="tarjeta">
+            <div class="tarjeta-cuerpo">
+              <p class="tarjeta-titulo">{{ sitio.name }}</p>
 
-            <NuxtLink
-              v-if="sitio.is_public && sitio.url"
-              class="boton boton-chico boton-secundario"
-              :to="`/tableros/${sitio.url}`"
-              target="_blank"
-              title="Ver URL pública"
-            >
-              <span class="pictograma-compartir m-r-1" />
-              /{{ sitio.url }}
-            </NuxtLink>
+              <p v-if="sitio.subtitle" class="tarjeta-etiqueta">{{ sitio.subtitle }}</p>
 
-            <template v-if="sitio.is_owner">
-              <button
-                class="boton boton-chico"
-                :class="sitio.is_public ? 'boton-secundario' : 'boton-primario'"
-                :title="sitio.is_public ? 'Hacer privado' : 'Hacer público'"
-                @click="togglearPublico(sitio)"
-              >
-                <i :class="sitio.is_public ? 'fas fa-eye' : 'fas fa-eye-slash'" class="m-r-1" />
-                {{ sitio.is_public ? 'Público' : 'Privado' }}
-              </button>
+              <p class="tarjeta-etiqueta">Creado: {{ formatearFecha(sitio.created) }}</p>
+            </div>
 
+            <div class="tarjeta-pie flex">
               <NuxtLink
                 class="boton boton-chico boton-secundario"
-                :to="`/geocontenidos/tableros/${sitio.id}`"
+                :to="`/tableros/${sitio.id}`"
+                target="_blank"
+                title="Previsualizar tablero"
               >
-                <span class="pictograma-editar m-r-1" />
-                Editar
+                <span class="pictograma-ojo-ver m-r-1" />
+                Previsualizar
               </NuxtLink>
 
-              <button class="boton boton-chico boton-primario" @click="borrarSitio(sitio.id)">
-                <span class="pictograma-eliminar m-r-1" />
-                Eliminar
-              </button>
-            </template>
+              <NuxtLink
+                v-if="sitio.is_public && sitio.url"
+                class="boton boton-chico boton-secundario"
+                :to="`/tableros/${sitio.url}`"
+                target="_blank"
+                title="Ver URL pública"
+              >
+                <span class="pictograma-compartir m-r-1" />
+                /{{ sitio.url }}
+              </NuxtLink>
+
+              <template v-if="sitio.is_owner">
+                <button
+                  class="boton boton-chico"
+                  :class="sitio.is_public ? 'boton-secundario' : 'boton-primario'"
+                  :title="sitio.is_public ? 'Hacer privado' : 'Hacer público'"
+                  @click="togglearPublico(sitio)"
+                >
+                  <i :class="sitio.is_public ? 'fas fa-eye' : 'fas fa-eye-slash'" class="m-r-1" />
+                  {{ sitio.is_public ? 'Público' : 'Privado' }}
+                </button>
+
+                <NuxtLink
+                  class="boton boton-chico boton-secundario"
+                  :to="`/geocontenidos/tableros/${sitio.id}`"
+                >
+                  <span class="pictograma-editar m-r-1" />
+                  Editar
+                </NuxtLink>
+
+                <button class="boton boton-chico boton-primario" @click="borrarSitio(sitio.id)">
+                  <span class="pictograma-eliminar m-r-1" />
+                  Eliminar
+                </button>
+              </template>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div v-else class="texto-centrado">
-      <p class="h3">No hay tableros disponibles.</p>
-    </div>
+      <div v-else class="texto-centrado">
+        <p class="h3">No hay tableros disponibles.</p>
+      </div> </template
+    ><!-- /v-else autenticado -->
   </div>
 </template>
 
 <style lang="scss" scoped>
+.sesion-requerida {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 4rem 2rem;
+  text-align: center;
+
+  &__icono {
+    font-size: 3rem;
+    color: var(--color-secundario-7, #876670);
+    opacity: 0.6;
+  }
+
+  &__titulo {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--color-primario-4, #991f47);
+    margin: 0;
+  }
+
+  &__desc {
+    font-size: 1rem;
+    color: var(--color-texto-secundario, #555);
+    max-width: 420px;
+    margin: 0;
+  }
+}
+
 .modulo-geocontenidos .contenedor {
   .grid.reticula-12 {
     grid-template-columns: repeat(12, 1fr);

--- a/pages/ia/proyecto/[id]/configurar.vue
+++ b/pages/ia/proyecto/[id]/configurar.vue
@@ -31,6 +31,7 @@ const campoBusqueda = ref('');
 
 const agregaCatalogoModal = ref(null);
 const seleccionCatalogoModal = ref(null);
+/* eslint-disable no-unused-vars */
 const dictTipoRecurso = {
   dataLayer: 'capas',
   dataTable: 'tablas',
@@ -264,6 +265,7 @@ function cargarArchivosGeonode() {
   archivosGeonode.value = [...archivosGeonode.value, ...nuevosArchivos];
   archivosTabla.value = [...archivosSeleccionados.value, ...archivosGeonode.value];
 }
+/* eslint-enable no-unused-vars */
 
 // Método para manejar la selección de archivos
 const manejarSeleccionArchivos = (event) => {
@@ -537,7 +539,7 @@ onBeforeUnmount(() => {
                   @change="manejarSeleccionArchivos"
                 />
                 <p class="m-y-1 texto-derecha">
-                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                  <small><b>Solo archivos PDF, CSV y Word.</b></small>
                 </p>
               </div>
             </div>

--- a/pages/ia/proyectos/crear-nuevo.vue
+++ b/pages/ia/proyectos/crear-nuevo.vue
@@ -204,6 +204,7 @@ async function removerBusqueda() {
 }
 
 // Abre el modal para elegir el tipo de fuente del catálogo
+// eslint-disable-next-line no-unused-vars
 function agregarFuentesCatalogo() {
   // limpiando recursos filtrados por categoría y seleccionados
   storeFilters.updateFilter('inputSearch', '');
@@ -490,7 +491,7 @@ onMounted(() => {
                   @change="manejarSeleccionArchivos"
                 />
                 <p class="m-y-1 texto-derecha">
-                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                  <small><b>Solo archivos PDF, CSV y Word.</b></small>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Resumen

- Agrega middleware `auth` a `/geocontenidos/tableros` (lista de tableros)
- Agrega middleware `auth` a `/geocontenidos/tableros/[sitio]` (vista de tablero)
- Los usuarios sin sesión activa son redirigidos al login

## Plan de prueba

- [ ] Acceder a `/geocontenidos/tableros` sin sesión y verificar redirección a login
- [ ] Acceder a `/geocontenidos/tableros/[id]` sin sesión y verificar redirección a login
- [ ] Con sesión activa, verificar que ambas rutas cargan correctamente