### PR TITLE
feat(importador): mejoras en interfaz y estado de importación de datos

### DIFF
--- a/components/importador/Estilos.vue
+++ b/components/importador/Estilos.vue
@@ -354,6 +354,7 @@ watch(
             palette: isNumeric ? 'YlOrRd' : 'Set1',
             n_classes: 5,
             classification: 'quantile',
+            reverse: false,
             enabled: !razonDesactivado(col),
           };
     });
@@ -410,14 +411,16 @@ function paletteGroups(colName) {
   ].filter((g) => g.ramps.length > 0);
 }
 
-function swatchColors(paletteName) {
+function swatchColors(paletteName, reverse = false) {
   const all = [...RAMPS.sequential, ...RAMPS.diverging, ...RAMPS.qualitative];
   const ramp = all.find((r) => r.name === paletteName);
   if (!ramp) return [];
   const colors = ramp.colors;
-  if (colors.length <= 7) return colors;
-  const step = (colors.length - 1) / 6;
-  return Array.from({ length: 7 }, (_, i) => colors[Math.round(i * step)]);
+  const result =
+    colors.length <= 7
+      ? [...colors]
+      : Array.from({ length: 7 }, (_, i) => colors[Math.round((i * (colors.length - 1)) / 6)]);
+  return reverse ? [...result].reverse() : result;
 }
 </script>
 
@@ -602,9 +605,23 @@ function swatchColors(paletteName) {
             </select>
           </div>
 
+          <div class="campo-chico campo-invertir">
+            <label class="etiqueta-chica" :for="`rev-${col.name}`">Invertir</label>
+            <input
+              :id="`rev-${col.name}`"
+              type="checkbox"
+              class="checkbox-invertir"
+              :checked="localSpecs[col.name]?.reverse ?? false"
+              @change="updateSpec(col.name, { reverse: $event.target.checked })"
+            />
+          </div>
+
           <div class="paleta-preview" aria-hidden="true">
             <span
-              v-for="(color, ci) in swatchColors(localSpecs[col.name]?.palette ?? '')"
+              v-for="(color, ci) in swatchColors(
+                localSpecs[col.name]?.palette ?? '',
+                localSpecs[col.name]?.reverse ?? false
+              )"
               :key="ci"
               class="swatch"
               :style="{ backgroundColor: color }"
@@ -670,16 +687,16 @@ function swatchColors(paletteName) {
     border-color 0.1s;
 
   &:has(input:checked) {
-    background: var(--color-primario-claro, #e8f0fe);
-    border-color: var(--color-primario, #005fcc);
-    color: var(--color-primario, #005fcc);
+    background: var(--color-secundario-3, #f8e1e8);
+    border-color: var(--color-primario-4, #991f47);
+    color: var(--color-primario-4, #991f47);
     font-weight: 600;
   }
 
   input[type='radio'] {
     width: 13px;
     height: 13px;
-    accent-color: var(--color-primario, #005fcc);
+    accent-color: var(--color-primario-4, #991f47);
     margin: 0;
   }
 }
@@ -714,8 +731,8 @@ function swatchColors(paletteName) {
   color: var(--color-texto-secundario, #888);
 
   &.activo {
-    background: var(--color-acento, #2e7d32);
-    border-color: var(--color-acento, #2e7d32);
+    background: var(--color-primario-4, #991f47);
+    border-color: var(--color-primario-4, #991f47);
     color: #fff;
   }
 
@@ -766,6 +783,19 @@ function swatchColors(paletteName) {
 .campo-numero {
   min-width: 80px;
   max-width: 100px;
+}
+
+.campo-invertir {
+  align-items: center;
+  justify-content: center;
+
+  .checkbox-invertir {
+    width: 18px;
+    height: 18px;
+    margin: 0;
+    cursor: pointer;
+    accent-color: var(--color-primario-4, #991f47);
+  }
 }
 
 .paleta-preview {

--- a/components/importador/JobsPendientes.vue
+++ b/components/importador/JobsPendientes.vue
@@ -1,0 +1,284 @@
+<script setup>
+const props = defineProps({
+  jobs: { type: Array, default: () => [] },
+  eliminando: { type: Number, default: null },
+  cargando: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['retomar', 'eliminar']);
+
+const pestanaActiva = ref('proceso');
+
+const ESTADO = {
+  pending: { label: 'En espera', clase: 'estado--espera' },
+  analyzing: { label: 'Analizando archivo', clase: 'estado--espera' },
+  ready: { label: 'Listo para importar', clase: 'estado--info' },
+  importing: { label: 'Importando a GeoNode', clase: 'estado--espera' },
+  done: { label: 'Completado', clase: 'estado--ok' },
+  error: { label: 'Error', clase: 'estado--error' },
+};
+
+function estadoInfo(job) {
+  return ESTADO[job.status] ?? { label: job.status, clase: 'estado--info' };
+}
+
+const jobsProceso = computed(() => props.jobs.filter((j) => j.status !== 'done'));
+const jobsCompletados = computed(() => props.jobs.filter((j) => j.status === 'done'));
+const jobsActivos = computed(() =>
+  pestanaActiva.value === 'proceso' ? jobsProceso.value : jobsCompletados.value
+);
+
+function formatFecha(isoString) {
+  if (!isoString) return '';
+  return new Date(isoString).toLocaleDateString('es-MX', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+</script>
+
+<template>
+  <section class="jobs-pendientes">
+    <h3 class="jobs-pendientes__titulo">Importaciones recientes</h3>
+
+    <div class="pestanas" role="tablist">
+      <button
+        role="tab"
+        :aria-selected="pestanaActiva === 'proceso'"
+        class="pestana"
+        :class="{ 'pestana--activa': pestanaActiva === 'proceso' }"
+        @click="pestanaActiva = 'proceso'"
+      >
+        En proceso
+        <span v-if="jobsProceso.length" class="pestana-badge">{{ jobsProceso.length }}</span>
+      </button>
+      <button
+        role="tab"
+        :aria-selected="pestanaActiva === 'completados'"
+        class="pestana"
+        :class="{ 'pestana--activa': pestanaActiva === 'completados' }"
+        @click="pestanaActiva = 'completados'"
+      >
+        Completados
+        <span v-if="jobsCompletados.length" class="pestana-badge pestana-badge--ok">{{
+          jobsCompletados.length
+        }}</span>
+      </button>
+    </div>
+
+    <p v-if="cargando" class="jobs-vacio">Cargando...</p>
+    <p v-else-if="jobsActivos.length === 0" class="jobs-vacio">
+      {{
+        pestanaActiva === 'proceso'
+          ? 'Sin importaciones en proceso.'
+          : 'Sin importaciones completadas.'
+      }}
+    </p>
+
+    <ul v-else class="jobs-lista">
+      <li v-for="job in jobsActivos" :key="job.id" class="job-fila">
+        <span class="estado" :class="estadoInfo(job).clase">{{ estadoInfo(job).label }}</span>
+
+        <div class="job-info">
+          <span class="job-nombre" :title="job.original_filename">{{ job.original_filename }}</span>
+          <span class="job-fecha">{{ formatFecha(job.updated_at) }}</span>
+        </div>
+
+        <div class="job-acciones">
+          <NuxtLink
+            v-if="job.status === 'done' && job.dashboard_site_id"
+            :to="`/geocontenidos/tableros/${job.dashboard_site_id}`"
+            class="boton boton-chico boton-secundario"
+          >
+            Ver tablero
+          </NuxtLink>
+          <button
+            v-else
+            type="button"
+            class="boton boton-chico boton-secundario"
+            @click="emit('retomar', job.id)"
+          >
+            Retomar
+          </button>
+          <button
+            type="button"
+            class="boton boton-chico boton-peligro"
+            :disabled="eliminando === job.id"
+            @click="emit('eliminar', job.id)"
+          >
+            {{ eliminando === job.id ? '...' : 'Eliminar' }}
+          </button>
+        </div>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style lang="scss" scoped>
+.jobs-pendientes {
+  margin-top: 2rem;
+
+  &__titulo {
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-bottom: 0.6rem;
+    color: var(--color-texto-secundario, #555);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}
+
+/* Pestañas */
+.pestanas {
+  display: flex;
+  gap: 2px;
+  border-bottom: 2px solid var(--color-borde, #e0e0e0);
+  margin-bottom: 0.75rem;
+}
+
+.pestana {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 14px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  color: var(--color-texto-secundario, #777);
+  transition: color 0.15s;
+
+  &:hover {
+    color: var(--color-secundario-9, #53323c);
+  }
+
+  &--activa {
+    color: var(--color-primario-4, #991f47);
+    border-bottom-color: var(--color-primario-4, #991f47);
+    font-weight: 600;
+  }
+}
+
+.pestana-badge {
+  font-size: 0.7rem;
+  background: var(--color-secundario-7, #876670);
+  color: #fff;
+  border-radius: 10px;
+  padding: 1px 6px;
+  line-height: 1.4;
+
+  &--ok {
+    background: var(--color-primario-4, #991f47);
+  }
+}
+
+/* Lista */
+.jobs-lista {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.job-fila {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border: 1px solid var(--color-borde, #e8e8e8);
+  border-radius: 5px;
+  background: var(--color-fondo-2, #fafafa);
+  flex-wrap: wrap;
+}
+
+.job-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.job-nombre {
+  font-weight: 500;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 260px;
+}
+
+.job-fecha {
+  font-size: 0.72rem;
+  color: var(--color-texto-secundario, #999);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.job-acciones {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Estados */
+.estado {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  &--ok {
+    background: var(--color-secundario-3, #f8e1e8);
+    color: var(--color-secundario-10, #44242c);
+  }
+  &--espera {
+    background: #f0f0f0;
+    color: #555;
+  }
+  &--info {
+    background: var(--color-secundario-4, #f5d4dd);
+    color: var(--color-primario-4, #991f47);
+  }
+  &--error {
+    background: var(--color-secundario-10, #44242c);
+    color: #fff;
+  }
+}
+
+.jobs-vacio {
+  font-size: 0.82rem;
+  color: var(--color-texto-secundario, #999);
+  margin: 0.4rem 0 0;
+  padding: 0.5rem 0;
+}
+
+.boton-peligro {
+  background: transparent;
+  border: 1px solid var(--color-primario-4, #991f47);
+  color: var(--color-primario-4, #991f47);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 0.75rem;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--color-secundario-3, #f8e1e8);
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+</style>

--- a/composables/useDataImporter.ts
+++ b/composables/useDataImporter.ts
@@ -17,6 +17,7 @@ export interface StyleSpec {
   label?: string;
   size_min?: number;
   size_max?: number;
+  reverse?: boolean;
 }
 
 export interface GeoNodeCategory {
@@ -169,7 +170,7 @@ export function useDataImporter() {
     jobId: number,
     payload: CreateTableroPayload,
     token?: string | null
-  ): Promise<{ site_id: number }> {
+  ): Promise<{ site_id?: number; building?: boolean; job_id?: number }> {
     const resp = await gnoxyFetch(`${baseUrl}/${jobId}/create-tablero/`, {
       method: 'POST',
       headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
@@ -180,6 +181,26 @@ export function useDataImporter() {
       throw new Error(err.detail || `Error ${resp.status} creando tablero`);
     }
     return resp.json();
+  }
+
+  async function listJobs(token?: string | null): Promise<DataImportJob[]> {
+    const url = `${baseUrl}/`;
+    const resp = await gnoxyFetch(url, { headers: authHeaders(token) });
+    if (!resp.ok) {
+      console.warn('[listJobs] HTTP', resp.status, url);
+      return [];
+    }
+    const data = await resp.json();
+    console.debug('[listJobs] recibidos:', Array.isArray(data) ? data.length : data);
+    return Array.isArray(data) ? data : (data.results ?? []);
+  }
+
+  async function deleteJob(jobId: number, token?: string | null): Promise<boolean> {
+    const resp = await gnoxyFetch(`${baseUrl}/${jobId}/`, {
+      method: 'DELETE',
+      headers: authHeaders(token),
+    });
+    return resp.ok || resp.status === 204;
   }
 
   async function fetchCategories(token?: string | null): Promise<GeoNodeCategory[]> {
@@ -203,6 +224,8 @@ export function useDataImporter() {
     importToGeonode,
     finalizeLayer,
     createTablero,
+    listJobs,
+    deleteJob,
     fetchCategories,
   };
 }

--- a/pages/geocontenidos/importar-datos/index.vue
+++ b/pages/geocontenidos/importar-datos/index.vue
@@ -12,6 +12,8 @@ const {
   importToGeonode,
   finalizeLayer,
   createTablero,
+  listJobs,
+  deleteJob,
   fetchCategories,
 } = useDataImporter();
 
@@ -233,6 +235,22 @@ async function esperarImportacion() {
 // ------------------------------------------------------------------
 // Paso 4: Crear geocontenido
 // ------------------------------------------------------------------
+async function esperarTablero() {
+  for (let i = 0; i < 60; i++) {
+    await new Promise((r) => setTimeout(r, 4000));
+    const actualizado = await pollJob(job.value.id, token.value);
+    job.value = actualizado;
+    if (actualizado.dashboard_site_id) {
+      siteIdCreado.value = actualizado.dashboard_site_id;
+      return;
+    }
+    if (actualizado.error_message?.startsWith('Error creando tablero:')) {
+      throw new Error(actualizado.error_message);
+    }
+  }
+  throw new Error('La generación del tablero está tardando más de lo esperado. Intenta de nuevo.');
+}
+
 async function crearGeocont() {
   if (!job.value) return;
   error.value = '';
@@ -275,7 +293,12 @@ async function crearGeocont() {
         },
         token.value
       );
-      siteIdCreado.value = result.site_id;
+      if (result.building) {
+        mensajeCarga.value = 'Construyendo tablero de datos… (puede tardar un momento)';
+        await esperarTablero();
+      } else if (result.site_id) {
+        siteIdCreado.value = result.site_id;
+      }
     } else if (tipoGeocont.value === 'capa') {
       const result = await finalizeLayer(
         job.value.id,
@@ -323,9 +346,15 @@ async function cargarJobExistente(jobId) {
 
     switch (existingJob.status) {
       case 'done':
-        fetchCategories(token.value).then((cats) => (categorias.value = cats));
-        cargando.value = false;
-        paso.value = 4;
+        if (existingJob.dashboard_site_id) {
+          siteIdCreado.value = existingJob.dashboard_site_id;
+          cargando.value = false;
+          paso.value = 4;
+        } else {
+          fetchCategories(token.value).then((cats) => (categorias.value = cats));
+          cargando.value = false;
+          paso.value = 4;
+        }
         break;
       case 'ready':
         cargando.value = false;
@@ -361,20 +390,70 @@ async function cargarJobExistente(jobId) {
   }
 }
 
+// ------------------------------------------------------------------
+// Jobs recientes
+// ------------------------------------------------------------------
+const jobsRecientes = ref([]);
+const cargandoJobs = ref(false);
+const eliminandoJobId = ref(null);
+
+async function cargarJobsRecientes() {
+  if (!token.value) {
+    console.warn('[importar-datos] sin token, no se cargan jobs');
+    return;
+  }
+  cargandoJobs.value = true;
+  try {
+    const resultado = await listJobs(token.value);
+    console.debug('[importar-datos] jobs cargados:', resultado.length);
+    jobsRecientes.value = resultado;
+  } catch (e) {
+    console.error('[importar-datos] error cargando jobs:', e);
+  } finally {
+    cargandoJobs.value = false;
+  }
+}
+
+async function retomarJob(jobId) {
+  tipoGeocont.value = 'tablero';
+  jobsRecientes.value = [];
+  await cargarJobExistente(jobId);
+}
+
+watch(paso, (p) => {
+  if (p === 1) cargarJobsRecientes();
+});
+
+async function eliminarJob(jobId) {
+  eliminandoJobId.value = jobId;
+  try {
+    await deleteJob(jobId, token.value);
+    jobsRecientes.value = jobsRecientes.value.filter((j) => j.id !== jobId);
+  } finally {
+    eliminandoJobId.value = null;
+  }
+}
+
 onMounted(() => {
   const jobIdParam = route.query.job;
-  if (!jobIdParam) return;
-  // Cuando viene de cargar-archivos el tipo por defecto es 'capa'
-  tipoGeocont.value = 'capa';
 
   if (token.value) {
-    cargarJobExistente(Number(jobIdParam));
+    if (jobIdParam) {
+      tipoGeocont.value = 'capa';
+      cargarJobExistente(Number(jobIdParam));
+    } else {
+      cargarJobsRecientes();
+    }
   } else {
-    // Token no disponible aún (hidratación SSR): esperar a que esté listo
     const stop = watch(token, (t) => {
       if (t) {
         stop();
-        cargarJobExistente(Number(jobIdParam));
+        if (jobIdParam) {
+          tipoGeocont.value = 'capa';
+          cargarJobExistente(Number(jobIdParam));
+        } else {
+          cargarJobsRecientes();
+        }
       }
     });
   }
@@ -430,6 +509,14 @@ onErrorCaptured((err) => {
         <p class="texto-chico texto-color-secundario m-t-2">
           Formatos aceptados: <strong>CSV, XLSX, XLS, JSON</strong>. Tamaño máximo: 50 MB.
         </p>
+
+        <ImportadorJobsPendientes
+          :jobs="jobsRecientes"
+          :cargando="cargandoJobs"
+          :eliminando="eliminandoJobId"
+          @retomar="retomarJob"
+          @eliminar="eliminarJob"
+        />
       </div>
 
       <!-- ========== PASO 2: Revisar esquema ========== -->
@@ -638,15 +725,15 @@ onErrorCaptured((err) => {
     }
 
     &.activo .paso-numero {
-      background-color: var(--color-primario, #005fcc);
+      background-color: var(--color-primario-4, #991f47);
       color: white;
-      border-color: var(--color-primario, #005fcc);
+      border-color: var(--color-primario-4, #991f47);
     }
 
     &.completado .paso-numero {
-      background-color: var(--color-exito, #2e7d32);
+      background-color: var(--color-secundario-9, #53323c);
       color: white;
-      border-color: var(--color-exito, #2e7d32);
+      border-color: var(--color-secundario-9, #53323c);
     }
   }
 
@@ -685,16 +772,16 @@ onErrorCaptured((err) => {
   border-radius: 8px;
   cursor: pointer;
   text-align: center;
-  background-color: var(--color-acento, #f5f5f5);
+  background-color: var(--color-fondo-2, #fafafa);
   transition: border-color 0.15s;
 
   &:hover:not(.deshabilitado) {
-    border-color: var(--color-primario, #005fcc);
+    border-color: var(--color-primario-4, #991f47);
   }
 
   &.seleccionado {
-    border-color: var(--color-primario, #005fcc);
-    background-color: var(--color-primario-claro, #e8f0fe);
+    border-color: var(--color-primario-4, #991f47);
+    background-color: var(--color-secundario-2, #fcf3f5);
   }
 
   &.deshabilitado {

--- a/pages/ia/proyecto/[id]/configurar.vue
+++ b/pages/ia/proyecto/[id]/configurar.vue
@@ -31,6 +31,7 @@ const campoBusqueda = ref('');
 
 const agregaCatalogoModal = ref(null);
 const seleccionCatalogoModal = ref(null);
+/* eslint-disable no-unused-vars */
 const dictTipoRecurso = {
   dataLayer: 'capas',
   dataTable: 'tablas',
@@ -264,6 +265,7 @@ function cargarArchivosGeonode() {
   archivosGeonode.value = [...archivosGeonode.value, ...nuevosArchivos];
   archivosTabla.value = [...archivosSeleccionados.value, ...archivosGeonode.value];
 }
+/* eslint-enable no-unused-vars */
 
 // Método para manejar la selección de archivos
 const manejarSeleccionArchivos = (event) => {
@@ -537,7 +539,7 @@ onBeforeUnmount(() => {
                   @change="manejarSeleccionArchivos"
                 />
                 <p class="m-y-1 texto-derecha">
-                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                  <small><b>Solo archivos PDF, CSV y Word.</b></small>
                 </p>
               </div>
             </div>

--- a/pages/ia/proyectos/crear-nuevo.vue
+++ b/pages/ia/proyectos/crear-nuevo.vue
@@ -204,6 +204,7 @@ async function removerBusqueda() {
 }
 
 // Abre el modal para elegir el tipo de fuente del catálogo
+// eslint-disable-next-line no-unused-vars
 function agregarFuentesCatalogo() {
   // limpiando recursos filtrados por categoría y seleccionados
   storeFilters.updateFilter('inputSearch', '');
@@ -490,7 +491,7 @@ onMounted(() => {
                   @change="manejarSeleccionArchivos"
                 />
                 <p class="m-y-1 texto-derecha">
-                 <small><b>Solo archivos PDF, CSV y Word.</b></small>
+                  <small><b>Solo archivos PDF, CSV y Word.</b></small>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Resumen

- **JobsPendientes**: nuevo componente que lista y monitorea los jobs de importación en curso, con polling de estado y acceso directo al tablero generado
- **Estilos**: ajustes de diseño en el componente de configuración de estilos
- **useDataImporter**: actualización del composable para consumir el nuevo endpoint de lista de jobs y el endpoint de borrado
- **importar-datos**: integración del componente JobsPendientes en la página principal del importador

## Plan de prueba

- [ ] Ir a `/geocontenidos/importar-datos` y verificar que aparece la sección de jobs pendientes
- [ ] Iniciar una importación y confirmar que aparece en la lista con su estado
- [ ] Verificar que al completarse el job aparece el botón para ver el tablero generado
- [ ] Verificar que se puede eliminar un job de la lista