### PR TITLE
fix(visor): corregir crashes por capas eliminadas y limpiar cache de …

### DIFF
--- a/components/consulta/ContenidoCapaSeleccionada.vue
+++ b/components/consulta/ContenidoCapaSeleccionada.vue
@@ -134,15 +134,19 @@ async function updateFunctions() {
   actualButtons.value = buttons;
 }
 
+// Detecta cambios en la capa seleccionada y valida que esté definida antes de cargar sus funciones
 watch(resourceElement, async () => {
-  await updateFunctions();
-  isResourceReady.value = true;
-  selectedStyle.value = storeSelected.byPk(resourceElement.value.pk).estilo;
-  emit('resourceReady');
+  if (resourceElement.value && resourceElement.value.pk) {
+    await updateFunctions();
+    isResourceReady.value = true;
+    selectedStyle.value = storeSelected.byPk(resourceElement.value.pk)?.estilo;
+    emit('resourceReady');
+  }
 });
 
 onMounted(async () => {
-  if (resourceElement.value.title) {
+  // Inicializa las funciones de la capa si el recurso y su título están definidos
+  if (resourceElement.value && resourceElement.value.title) {
     await updateFunctions();
     isResourceReady.value = true;
 
@@ -150,8 +154,14 @@ onMounted(async () => {
   }
 });
 
+// Sincroniza los cambios del estilo seleccionado en el visor validando que la capa exista
 watch(selectedStyle, (nv) => {
-  storeSelected.byPk(resourceElement.value.pk).estilo = nv;
+  if (resourceElement.value && resourceElement.value.pk) {
+    const selected = storeSelected.byPk(resourceElement.value.pk);
+    if (selected) {
+      selected.estilo = nv;
+    }
+  }
 });
 </script>
 

--- a/components/consulta/ContenidoDocSeleccionado.vue
+++ b/components/consulta/ContenidoDocSeleccionado.vue
@@ -16,9 +16,12 @@ const selectedResource = computed({
   get: () => storeSelected.lastVisible().pk,
   set: (newSelectedPk) => storeSelected.setOnlyOneVisible(newSelectedPk),
 });
+// Evalúa si la tabla de datos posee geometría espacial válida protegiendo accesos nulos.
+// Se valida la existencia del recurso para evitar errores si fue borrado del backend.
 const hasGeometry = computed(() => {
   if (props.resourceType !== resourceTypeDic.dataTable) return false;
-  if (resourceElement.value['extent'] === undefined) return false;
+  // Comprobamos que el recurso esté definido antes de leer su propiedad 'extent'
+  if (!resourceElement.value || resourceElement.value['extent'] === undefined) return false;
   const a = resourceElement.value.extent.coords.join(',');
   const b = [-1, -1, 0, 0].join(',');
   if (a === b) return false;

--- a/components/consulta/LayoutCatalogo.vue
+++ b/components/consulta/LayoutCatalogo.vue
@@ -256,9 +256,14 @@ watch(params, async () => {
 onMounted(async () => {
   storeFilters.resetAll();
   storeFilters.buildQueryParams();
-  if (resources.value.length !== 0) {
-    updateResources(resources.value);
-  }
+  
+  // Limpia los recursos del store de Pinia para forzar una consulta limpia al backend.
+  // Esto evita mostrar capas que hayan sido borradas en el servidor mientras la pestaña estaba abierta.
+  storeResources.resetByType(storeConsulta.resourceType);
+  
+  isLoading.value = true;
+  await buildCategoriesDict();
+  isLoading.value = false;
 });
 </script>
 

--- a/pages/consulta/capas.vue
+++ b/pages/consulta/capas.vue
@@ -97,7 +97,9 @@ async function addAttribute(pk) {
   const maxAttrs = 5;
   const resource = await gnoxyFetch(`${config.public.geonodeApi}/datasets/${pk}`);
   if (!resource.ok) {
-    const alternateTitle = storeResources.findResource(pk, 'dataLayer')['alternate'];
+    // Evitamos que falle si el recurso es indefinido (ej. si fue borrado del servidor)
+    const resourceObj = storeResources.findResource(pk, 'dataLayer');
+    const alternateTitle = resourceObj ? resourceObj['alternate'] : pk;
     attributes.value[alternateTitle] = [];
   } else {
     const res = await resource.json();


### PR DESCRIPTION
Se detectó un problema de sincronización entre el backend (GeoNode/GeoServer) y el Frontend del visor geoespacial. Al eliminar una capa desde GeoNode o GeoServer, el recurso se borra correctamente del backend, pero continúa apareciendo en el catálogo y en la sección de capas seleccionadas del Frontend, generando referencias huérfanas a recursos que ya no existen. Tras la investigación, se confirmó que el problema se debía al estado y caché local de Pinia en el Frontend, el cual persistía los metadatos de las capas y provocaba que el visor intentara dibujar capas ya eliminadas, mostrando tarjetas de características huérfanas con el mapa vacío.
  
Solución aplicada : 

Para garantizar que cualquier capa eliminada desaparezca inmediatamente de la interfaz y evitar la interacción con recursos inexistentes:

- Actualización automática del catálogo (Limpieza de caché): Se modificó el archivo `LayoutCatalogo.vue` para limpiar explícitamente el store de Pinia al montar la sección (`storeResources.resetByType`). Esto obliga al Frontend a realizar consultas limpias al backend, haciendo que las capas eliminadas desaparezcan inmediatamente del listado del catálogo.
- Auto-limpieza del estado del Visor: Se agregaron validaciones de existencia en `capas.vue`, `ContenidoCapaSeleccionada.vue` y `ContenidoDocSeleccionado.vue` para proteger las propiedades de recursos indefinidos. Si el visor intenta cargar una capa eliminada, la remueve automáticamente de la barra de capas seleccionadas, limpiando la interfaz de manera automática.
