### PR TITLE
Agrega banda institucional configurable en tableros

### DIFF
--- a/components/tableros/BandaInstitucional.vue
+++ b/components/tableros/BandaInstitucional.vue
@@ -1,0 +1,87 @@
+<script setup>
+const props = defineProps({
+  sitio: {
+    type: Object,
+    default: null,
+  },
+});
+
+const topBar = computed(() => props.sitio?.top_bar);
+
+const estilosBanda = computed(() => {
+  if (!topBar.value) return {};
+  return {
+    backgroundColor: topBar.value.background_color || '#ffffff',
+    color: topBar.value.text_color || '#333333',
+    height: topBar.value.height ? `${topBar.value.height}px` : '60px',
+  };
+});
+</script>
+
+<template>
+  <div v-if="topBar?.show" class="banda-institucional" :style="estilosBanda">
+    <div class="banda-institucional__contenido">
+      <p v-if="topBar.title" class="banda-institucional__titulo">
+        {{ topBar.title }}
+      </p>
+      <div v-if="topBar.logos?.length" class="banda-institucional__logos">
+        <a
+          v-for="logo in topBar.logos"
+          :key="logo.id"
+          :href="logo.icon_link || undefined"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="banda-institucional__logo"
+        >
+          <img :src="logo.icon || logo.icon_url" :alt="logo.alt_text || sitio?.name" />
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.banda-institucional {
+  width: 100%;
+
+  &__contenido {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 100%;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    gap: 1.5rem;
+  }
+
+  &__titulo {
+    margin: 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  &__logos {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    margin-left: auto;
+  }
+
+  &__logo {
+    display: flex;
+    align-items: center;
+    background: #ffffff;
+    border-radius: 6px;
+    padding: 5px 12px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+
+    img {
+      max-height: 36px;
+      width: auto;
+      object-fit: contain;
+    }
+  }
+}
+</style>

--- a/components/tableros/admin/SubidorLogosTopBar.vue
+++ b/components/tableros/admin/SubidorLogosTopBar.vue
@@ -1,0 +1,359 @@
+<script setup>
+const props = defineProps({
+  topBarId: {
+    type: Number,
+    required: true,
+  },
+});
+
+const { data: userData } = useAuth();
+const { gnoxyUrl } = useGnoxyUrl();
+const {
+  crearLogoTopBar,
+  actualizarLogoTopBar,
+  eliminarLogoTopBar,
+  reordenarLogosTopBar,
+  fetchTopBar,
+} = useTableroApi();
+
+const logos = ref([]);
+const cargando = ref(false);
+const subiendo = ref(false);
+const inputArchivo = ref(null);
+
+// Estado del logo que se va a crear
+const nuevoLink = ref('');
+const nuevaUrlImagen = ref('');
+const nuevoAlt = ref('');
+
+async function cargar() {
+  cargando.value = true;
+  try {
+    const tb = await fetchTopBar(props.topBarId);
+    logos.value = tb.logos || [];
+  } catch (e) {
+    console.error('Error al cargar logos de banda:', e);
+  } finally {
+    cargando.value = false;
+  }
+}
+
+async function subirArchivo(event) {
+  const archivo = event.target.files?.[0];
+  if (!archivo) return;
+
+  subiendo.value = true;
+  try {
+    const form = new FormData();
+    form.append('top_bar', String(props.topBarId));
+    form.append('icon', archivo);
+    if (nuevoLink.value) form.append('icon_link', nuevoLink.value);
+    if (nuevoAlt.value) form.append('alt_text', nuevoAlt.value);
+    form.append('stack_order', String(logos.value.length + 1));
+
+    const creado = await crearLogoTopBar(form, userData.value?.accessToken);
+    if (creado?.id) {
+      logos.value.push(creado);
+      nuevoLink.value = '';
+      nuevaUrlImagen.value = '';
+      nuevoAlt.value = '';
+      if (inputArchivo.value) inputArchivo.value.value = '';
+    } else {
+      console.error('Error al crear logo de banda:', JSON.stringify(creado));
+      alert(`Error al subir logo:\n${JSON.stringify(creado, null, 2)}`);
+    }
+  } catch (e) {
+    console.error('Error al subir logo de banda:', e);
+  } finally {
+    subiendo.value = false;
+  }
+}
+
+async function agregarUrlExterna() {
+  if (!nuevaUrlImagen.value) return;
+
+  subiendo.value = true;
+  try {
+    const form = new FormData();
+    form.append('top_bar', String(props.topBarId));
+    form.append('icon_url', nuevaUrlImagen.value);
+    if (nuevoLink.value) form.append('icon_link', nuevoLink.value);
+    if (nuevoAlt.value) form.append('alt_text', nuevoAlt.value);
+    form.append('stack_order', String(logos.value.length + 1));
+
+    const creado = await crearLogoTopBar(form, userData.value?.accessToken);
+    if (creado?.id) {
+      logos.value.push(creado);
+      nuevoLink.value = '';
+      nuevaUrlImagen.value = '';
+      nuevoAlt.value = '';
+    } else {
+      alert(`Error:\n${JSON.stringify(creado, null, 2)}`);
+    }
+  } catch (e) {
+    console.error('Error al agregar URL externa:', e);
+  } finally {
+    subiendo.value = false;
+  }
+}
+
+async function actualizarCampo(logo, campo) {
+  const form = new FormData();
+  form.append(campo, logo[campo] || '');
+  await actualizarLogoTopBar(logo.id, form, userData.value?.accessToken);
+}
+
+async function quitar(id) {
+  if (!confirm('¿Eliminar este logo de la banda?')) return;
+  const ok = await eliminarLogoTopBar(id, userData.value?.accessToken);
+  if (ok) logos.value = logos.value.filter((l) => l.id !== id);
+}
+
+async function mover(idx, dir) {
+  const nuevo = idx + dir;
+  if (nuevo < 0 || nuevo >= logos.value.length) return;
+
+  const copia = [...logos.value];
+  [copia[idx], copia[nuevo]] = [copia[nuevo], copia[idx]];
+  logos.value = copia.map((l, i) => ({ ...l, stack_order: i + 1 }));
+
+  const items = logos.value.map((l) => ({ id: l.id, stack_order: l.stack_order }));
+  await reordenarLogosTopBar(items, userData.value?.accessToken);
+}
+
+watch(() => props.topBarId, cargar, { immediate: true });
+</script>
+
+<template>
+  <div class="subidor-logos-topbar">
+    <h4 class="subidor-logos-topbar__subtitulo">Logos de la banda</h4>
+
+    <div v-if="cargando"><GeocontenidosLoader mensaje="Cargando logos..." /></div>
+
+    <ul v-else-if="logos.length" class="subidor-logos-topbar__lista">
+      <li v-for="(logo, idx) in logos" :key="logo.id" class="subidor-logos-topbar__item">
+        <img
+          v-if="logo.icon || logo.icon_url"
+          :src="logo.icon ? gnoxyUrl(logo.icon) : logo.icon_url"
+          :alt="logo.alt_text || `Logo ${idx + 1}`"
+          class="subidor-logos-topbar__preview"
+        />
+        <div v-else class="subidor-logos-topbar__sin-imagen">Sin imagen</div>
+
+        <div class="subidor-logos-topbar__campos">
+          <label :for="`topbar-alt-${logo.id}`" class="formulario-ayuda">Texto alternativo</label>
+          <input
+            :id="`topbar-alt-${logo.id}`"
+            v-model="logo.alt_text"
+            type="text"
+            placeholder="Ej: Logo SENER"
+            @blur="actualizarCampo(logo, 'alt_text')"
+          />
+          <label :for="`topbar-img-${logo.id}`" class="formulario-ayuda m-t-1"
+            >URL imagen externa</label
+          >
+          <input
+            :id="`topbar-img-${logo.id}`"
+            v-model="logo.icon_url"
+            type="url"
+            placeholder="https://ejemplo.com/logo.svg"
+            @blur="actualizarCampo(logo, 'icon_url')"
+          />
+          <label :for="`topbar-link-${logo.id}`" class="formulario-ayuda m-t-1"
+            >Enlace al hacer clic</label
+          >
+          <input
+            :id="`topbar-link-${logo.id}`"
+            v-model="logo.icon_link"
+            type="url"
+            placeholder="https://"
+            @blur="actualizarCampo(logo, 'icon_link')"
+          />
+        </div>
+
+        <div class="subidor-logos-topbar__acciones">
+          <button
+            type="button"
+            class="boton boton-secundario boton-chico"
+            :disabled="idx === 0"
+            @click="mover(idx, -1)"
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            class="boton boton-secundario boton-chico"
+            :disabled="idx === logos.length - 1"
+            @click="mover(idx, 1)"
+          >
+            ↓
+          </button>
+          <button type="button" class="boton boton-primario boton-chico" @click="quitar(logo.id)">
+            <span class="pictograma-eliminar" />
+          </button>
+        </div>
+      </li>
+    </ul>
+
+    <p v-else class="formulario-ayuda">No hay logos en la banda todavía.</p>
+
+    <!-- Agregar nuevo logo -->
+    <div class="subidor-logos-topbar__nuevo">
+      <p class="formulario-etiqueta">Agregar logo</p>
+
+      <div class="subidor-logos-topbar__nuevo-campos">
+        <label for="topbar-nuevo-alt" class="formulario-ayuda">Texto alternativo</label>
+        <input id="topbar-nuevo-alt" v-model="nuevoAlt" type="text" placeholder="Ej: Logo SENER" />
+        <label for="topbar-nuevo-link" class="formulario-ayuda m-t-1">Enlace al hacer clic</label>
+        <input id="topbar-nuevo-link" v-model="nuevoLink" type="url" placeholder="https://" />
+      </div>
+
+      <div class="subidor-logos-topbar__nuevo-opciones">
+        <div class="subidor-logos-topbar__opcion">
+          <p class="formulario-ayuda">Opción A — subir archivo</p>
+          <input
+            ref="inputArchivo"
+            type="file"
+            accept="image/*"
+            :disabled="subiendo"
+            @change="subirArchivo"
+          />
+        </div>
+
+        <div class="subidor-logos-topbar__separador">o</div>
+
+        <div class="subidor-logos-topbar__opcion">
+          <label for="topbar-nuevo-url" class="formulario-ayuda"
+            >Opción B — URL externa de imagen</label
+          >
+          <div class="subidor-logos-topbar__url-fila">
+            <input
+              id="topbar-nuevo-url"
+              v-model="nuevaUrlImagen"
+              type="url"
+              placeholder="https://ejemplo.com/logo.svg"
+              :disabled="subiendo"
+            />
+            <button
+              type="button"
+              class="boton boton-secundario boton-chico"
+              :disabled="subiendo || !nuevaUrlImagen"
+              @click="agregarUrlExterna"
+            >
+              Agregar
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <p v-if="subiendo" class="formulario-ayuda">Guardando...</p>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.subidor-logos-topbar {
+  &__subtitulo {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.75rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-neutro-2, #e0e0e0);
+  }
+
+  &__lista {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+  }
+
+  &__item {
+    display: grid;
+    grid-template-columns: 80px 1fr auto;
+    align-items: start;
+    gap: 1rem;
+    padding: 0.75rem;
+    border: 1px solid var(--color-neutro-2, #e0e0e0);
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+  }
+
+  &__preview {
+    width: 72px;
+    height: 48px;
+    object-fit: contain;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    padding: 4px;
+  }
+
+  &__sin-imagen {
+    width: 72px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    color: #999;
+    border: 1px dashed #ccc;
+    border-radius: 4px;
+  }
+
+  &__campos {
+    display: flex;
+    flex-direction: column;
+
+    input {
+      margin-top: 0.15rem;
+    }
+  }
+
+  &__acciones {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__nuevo {
+    padding: 1rem;
+    border: 1px dashed var(--color-neutro-2, #e0e0e0);
+    border-radius: 6px;
+    margin-top: 0.5rem;
+  }
+
+  &__nuevo-campos {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
+  }
+
+  &__nuevo-opciones {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  &__opcion {
+    flex: 1;
+    min-width: 200px;
+  }
+
+  &__separador {
+    font-weight: bold;
+    color: #999;
+    padding: 0 0.5rem;
+  }
+
+  &__url-fila {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 0.15rem;
+
+    input {
+      flex: 1;
+    }
+  }
+}
+</style>

--- a/components/tableros/admin/TabBandaInstitucional.vue
+++ b/components/tableros/admin/TabBandaInstitucional.vue
@@ -1,0 +1,292 @@
+<script setup>
+const props = defineProps({
+  siteId: {
+    type: Number,
+    required: true,
+  },
+});
+
+const { data: userData } = useAuth();
+const { fetchTopBar, actualizarTopBar } = useTableroApi();
+
+const topBar = ref(null);
+const cargando = ref(false);
+const guardando = ref(false);
+const mensajeGuardado = ref('');
+
+// Formulario local (espejo del topBar del servidor)
+const form = reactive({
+  show: false,
+  title: '',
+  background_color: '#ffffff',
+  text_color: '#333333',
+  height: 60,
+});
+
+async function cargar() {
+  cargando.value = true;
+  try {
+    const datos = await fetchTopBar(props.siteId);
+    topBar.value = datos;
+    Object.assign(form, {
+      show: datos.show,
+      title: datos.title || '',
+      background_color: datos.background_color || '#ffffff',
+      text_color: datos.text_color || '#333333',
+      height: datos.height || 60,
+    });
+  } catch (e) {
+    console.error('Error al cargar banda institucional:', e);
+  } finally {
+    cargando.value = false;
+  }
+}
+
+async function guardar() {
+  guardando.value = true;
+  mensajeGuardado.value = '';
+  try {
+    const actualizado = await actualizarTopBar(
+      props.siteId,
+      { ...form },
+      userData.value?.accessToken
+    );
+    if (actualizado?.id) {
+      topBar.value = actualizado;
+      mensajeGuardado.value = 'Cambios guardados.';
+      setTimeout(() => {
+        mensajeGuardado.value = '';
+      }, 3000);
+    }
+  } catch (e) {
+    console.error('Error al guardar banda institucional:', e);
+  } finally {
+    guardando.value = false;
+  }
+}
+
+watch(() => props.siteId, cargar, { immediate: true });
+</script>
+
+<template>
+  <div class="tab-banda">
+    <div v-if="cargando"><GeocontenidosLoader mensaje="Cargando configuración..." /></div>
+
+    <template v-else-if="topBar">
+      <div class="tab-banda__seccion">
+        <h3 class="tab-banda__titulo-seccion">Configuración de la banda</h3>
+
+        <div class="tab-banda__campo">
+          <label class="formulario-etiqueta" for="banda-show"> Mostrar banda institucional </label>
+          <input id="banda-show" v-model="form.show" type="checkbox" />
+        </div>
+
+        <div class="tab-banda__campo">
+          <label class="formulario-etiqueta" for="banda-title">Título (lado izquierdo)</label>
+          <input
+            id="banda-title"
+            v-model="form.title"
+            type="text"
+            placeholder="Ej: Secretaría de Energía · CNE"
+            :disabled="!form.show"
+          />
+        </div>
+
+        <div class="tab-banda__fila">
+          <div class="tab-banda__campo">
+            <label class="formulario-etiqueta" for="banda-bg">Color de fondo</label>
+            <div class="tab-banda__color-fila">
+              <input
+                id="banda-bg"
+                v-model="form.background_color"
+                type="color"
+                :disabled="!form.show"
+              />
+              <input
+                v-model="form.background_color"
+                type="text"
+                maxlength="7"
+                placeholder="#ffffff"
+                :disabled="!form.show"
+              />
+            </div>
+          </div>
+
+          <div class="tab-banda__campo">
+            <label class="formulario-etiqueta" for="banda-text">Color de texto</label>
+            <div class="tab-banda__color-fila">
+              <input
+                id="banda-text"
+                v-model="form.text_color"
+                type="color"
+                :disabled="!form.show"
+              />
+              <input
+                v-model="form.text_color"
+                type="text"
+                maxlength="7"
+                placeholder="#333333"
+                :disabled="!form.show"
+              />
+            </div>
+          </div>
+
+          <div class="tab-banda__campo">
+            <label class="formulario-etiqueta" for="banda-height">Alto (px)</label>
+            <input
+              id="banda-height"
+              v-model.number="form.height"
+              type="number"
+              min="32"
+              max="120"
+              :disabled="!form.show"
+            />
+          </div>
+        </div>
+
+        <!-- Preview -->
+        <div
+          class="tab-banda__preview"
+          :style="{
+            backgroundColor: form.background_color,
+            color: form.text_color,
+            height: `${form.height}px`,
+          }"
+        >
+          <span v-if="form.title" class="tab-banda__preview-titulo">{{ form.title }}</span>
+          <span v-else class="tab-banda__preview-placeholder">Vista previa de la banda</span>
+          <div class="tab-banda__preview-logos">
+            <template v-for="logo in topBar.logos || []" :key="logo.id">
+              <img
+                v-if="logo.icon || logo.icon_url"
+                :src="logo.icon || logo.icon_url"
+                :alt="logo.alt_text"
+                style="max-height: 36px; width: auto; object-fit: contain"
+              />
+            </template>
+          </div>
+        </div>
+
+        <div class="tab-banda__acciones">
+          <button type="button" class="boton boton-primario" :disabled="guardando" @click="guardar">
+            {{ guardando ? 'Guardando...' : 'Guardar configuración' }}
+          </button>
+          <span v-if="mensajeGuardado" class="tab-banda__mensaje-ok">{{ mensajeGuardado }}</span>
+        </div>
+      </div>
+
+      <!-- Gestión de logos -->
+      <div class="tab-banda__seccion">
+        <TablerosAdminSubidorLogosTopBar :top-bar-id="topBar.id" />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.tab-banda {
+  padding: 1.5rem;
+
+  &__titulo-seccion {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+  }
+
+  &__seccion {
+    background: var(--color-neutro-1, #f8f8f8);
+    border: 1px solid var(--color-neutro-2, #e0e0e0);
+    border-radius: 8px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  &__campo {
+    margin-bottom: 1rem;
+
+    input[type='text'],
+    input[type='url'],
+    input[type='number'] {
+      display: block;
+      width: 100%;
+      margin-top: 0.25rem;
+    }
+
+    input[type='checkbox'] {
+      margin-left: 0.5rem;
+      width: auto;
+    }
+  }
+
+  &__fila {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 1rem;
+    align-items: start;
+  }
+
+  &__color-fila {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+
+    input[type='color'] {
+      width: 40px;
+      height: 36px;
+      padding: 2px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    input[type='text'] {
+      flex: 1;
+    }
+  }
+
+  &__preview {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 1rem;
+    border-radius: 4px;
+    margin: 1rem 0;
+    border: 1px dashed #ccc;
+    transition:
+      background-color 0.2s,
+      color 0.2s,
+      height 0.2s;
+    overflow: hidden;
+  }
+
+  &__preview-titulo {
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+
+  &__preview-placeholder {
+    font-size: 0.8rem;
+    opacity: 0.5;
+    font-style: italic;
+  }
+
+  &__preview-logos {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  &__acciones {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 0.5rem;
+  }
+
+  &__mensaje-ok {
+    color: var(--color-exito, #2e7d32);
+    font-size: 0.875rem;
+  }
+}
+</style>

--- a/composables/useTableroApi.ts
+++ b/composables/useTableroApi.ts
@@ -67,7 +67,11 @@ export function useTableroApi() {
 
     fetchSitioPorUrl: async (urlSlug: string) => {
       const datos = await fetchJson(`${baseUrl}/sites/?url=${encodeURIComponent(urlSlug)}`);
-      return datos.results?.[0] ?? null;
+      const partial = datos.results?.[0] ?? null;
+      if (!partial?.id) return null;
+      // El endpoint de lista devuelve SiteListSerializer (sin logos/configuration/top_bar).
+      // Se necesita el retrieve para obtener los datos completos del tablero.
+      return fetchJson(`${baseUrl}/sites/${partial.id}/`);
     },
 
     crearSitio: (datos: unknown, token?: string | null) =>
@@ -142,6 +146,26 @@ export function useTableroApi() {
 
     reordenarLogos: (items: Array<{ id: number; stack_order: number }>, token?: string | null) =>
       jsonRequest(`${baseUrl}/site-logos/bulk-reorder/`, 'POST', items, token),
+
+    // ---------- Top bar institucional ----------
+    fetchTopBar: (siteId: number) => fetchJson(`${baseUrl}/top-bars/${siteId}/`),
+
+    actualizarTopBar: (siteId: number, datos: unknown, token?: string | null) =>
+      jsonRequest(`${baseUrl}/top-bars/${siteId}/`, 'PATCH', datos, token),
+
+    crearLogoTopBar: (form: FormData, token?: string | null) =>
+      formRequest(`${baseUrl}/top-bar-logos/`, 'POST', form, token),
+
+    actualizarLogoTopBar: (id: number, form: FormData, token?: string | null) =>
+      formRequest(`${baseUrl}/top-bar-logos/${id}/`, 'PATCH', form, token),
+
+    eliminarLogoTopBar: (id: number, token?: string | null) =>
+      deleteRequest(`${baseUrl}/top-bar-logos/${id}/`, token),
+
+    reordenarLogosTopBar: (
+      items: Array<{ id: number; stack_order: number }>,
+      token?: string | null
+    ) => jsonRequest(`${baseUrl}/top-bar-logos/bulk-reorder/`, 'POST', items, token),
 
     // ---------- Groups ----------
     fetchGrupos: (siteId: number) => fetchJson(`${baseUrl}/groups/?site=${siteId}`),

--- a/pages/geocontenidos/tableros/[sitio]/index.vue
+++ b/pages/geocontenidos/tableros/[sitio]/index.vue
@@ -123,6 +123,7 @@ async function guardar() {
 
 const pestanias = computed(() => [
   { id: 'identidad', titulo: 'Identidad del sitio' },
+  { id: 'banda', titulo: 'Banda institucional', deshabilitada: esNuevo.value },
   { id: 'estructura', titulo: 'Estructura', deshabilitada: esNuevo.value },
   { id: 'datos', titulo: 'Datos estáticos', deshabilitada: esNuevo.value },
 ]);
@@ -190,6 +191,10 @@ cargarSitio();
             @actualizar="aplicarCambios"
             @guardar="guardar"
           />
+        </template>
+
+        <template #contenido-banda>
+          <TablerosAdminTabBandaInstitucional v-if="sitio.id" :site-id="sitio.id" />
         </template>
 
         <template #contenido-estructura>

--- a/pages/tableros/[...sitio].vue
+++ b/pages/tableros/[...sitio].vue
@@ -183,6 +183,7 @@ cargarSitio();
         Editar tablero
       </NuxtLink>
 
+      <TablerosBandaInstitucional :sitio="sitio.datos" />
       <TablerosEncabezado :sitio="sitio.datos" />
 
       <TablerosNavGrupos :grupos="grupos" :activo="grupoActivo" @seleccionar="cambiarGrupo" />


### PR DESCRIPTION
## Resumen
- Agrega el componente `BandaInstitucional.vue` para mostrar la banda institucional en el tablero público.
- Agrega el panel de administración (`TabBandaInstitucional.vue`) y el subidor de logos (`SubidorLogosTopBar.vue`).
- Extiende `useTableroApi` con los métodos para consumir los endpoints de top-bars y top-bar-logos del backend.
- Depende del PR de backend en sigic-geonode-wrapper que agrega estos endpoints.

## Plan de pruebas
- [x] Configurar la banda institucional desde el panel de administración
- [ ] Subir, reordenar y eliminar logos de la banda
- [x] Verificar que la banda se muestre correctamente en el tablero público