### PR TITLE
fix: corregir formularios de edición del panel de tableros

### DIFF
--- a/components/tableros/admin/ArbolGrupo.vue
+++ b/components/tableros/admin/ArbolGrupo.vue
@@ -32,11 +32,11 @@ const detalle = ref(null);
 const cargandoDetalle = ref(false);
 
 const editandoGrupo = ref(false);
-const formularioGrupo = reactive({ name: '', description: '' });
+const formularioGrupo = reactive({ name: '', description: '', info_text: '' });
 const guardandoGrupo = ref(false);
 
 const subgrupoEditandoId = ref(null);
-const formularioSubgrupo = reactive({ name: '', icon: '' });
+const formularioSubgrupo = reactive({ name: '', icon: '', info_text: '' });
 const guardandoSubgrupo = ref(false);
 
 async function cargarDetalle() {
@@ -104,6 +104,8 @@ async function borrarSubgrupo(id) {
 }
 
 async function onDropGrupo(ev) {
+  ev.stopPropagation();
+
   const indicadorId = ev.dataTransfer.getData('indicator-id');
   if (!indicadorId) return;
   await actualizarIndicador(
@@ -116,6 +118,10 @@ async function onDropGrupo(ev) {
 }
 
 async function onDropSubgrupo(ev, subgrupoId) {
+  // Sin esto el 'drop' burbujea al contenedor del grupo (arbol-grupo__drop) y
+  // onDropGrupo también se dispara, sobreescribiendo esta asignación con subgroup: null.
+  ev.stopPropagation();
+
   const indicadorId = ev.dataTransfer.getData('indicator-id');
   if (!indicadorId) return;
   await actualizarIndicador(
@@ -140,6 +146,7 @@ async function desasignar(indicadorId) {
 function abrirEdicionGrupo() {
   formularioGrupo.name = props.grupo.name || '';
   formularioGrupo.description = props.grupo.description || '';
+  formularioGrupo.info_text = props.grupo.info_text || '';
   editandoGrupo.value = true;
 }
 
@@ -160,6 +167,7 @@ async function guardarGrupo() {
 function abrirEdicionSubgrupo(sg) {
   formularioSubgrupo.name = sg.name || '';
   formularioSubgrupo.icon = sg.icon || '';
+  formularioSubgrupo.info_text = sg.info_text || '';
   subgrupoEditandoId.value = sg.id;
 }
 
@@ -169,6 +177,7 @@ async function guardarSubgrupo(sgId) {
   const form = new FormData();
   form.append('name', formularioSubgrupo.name);
   if (formularioSubgrupo.icon) form.append('icon', formularioSubgrupo.icon);
+  form.append('info_text', formularioSubgrupo.info_text || '');
   try {
     await actualizarSubgrupo(sgId, form, userData.value?.accessToken);
     subgrupoEditandoId.value = null;
@@ -223,6 +232,11 @@ onMounted(cargarDetalle);
           type="text"
           placeholder="Descripción (opcional)"
         />
+        <textarea
+          v-model="formularioGrupo.info_text"
+          rows="2"
+          placeholder="Info (texto que aparece como ayuda del grupo, opcional)"
+        />
         <div class="arbol-grupo__edit-acciones">
           <button
             type="button"
@@ -250,6 +264,7 @@ onMounted(cargarDetalle);
             placeholder="Nombre del subgrupo"
             required
           />
+          <input v-model="nuevoSubgrupo.info_text" type="text" placeholder="Info (opcional)" />
           <TablerosAdminPickerIcono v-model="nuevoSubgrupo.icon" />
           <input type="submit" class="boton boton-primario boton-chico" value="Crear" />
         </form>
@@ -289,6 +304,11 @@ onMounted(cargarDetalle);
                     type="text"
                     placeholder="Nombre del subgrupo"
                     required
+                  />
+                  <input
+                    v-model="formularioSubgrupo.info_text"
+                    type="text"
+                    placeholder="Info (opcional)"
                   />
                   <TablerosAdminPickerIcono v-model="formularioSubgrupo.icon" />
                   <input

--- a/components/tableros/admin/FormularioCuadroDatos.vue
+++ b/components/tableros/admin/FormularioCuadroDatos.vue
@@ -13,7 +13,8 @@ const props = defineProps({
 const emit = defineEmits(['guardado', 'cerrar']);
 
 const { data: userData } = useAuth();
-const { crearCuadroDatos, actualizarCuadroDatos } = useTableroApi();
+const { crearCuadroDatos, actualizarCuadroDatos, fetchIndicador, fetchDatasetAttributes } =
+  useTableroApi();
 
 const modal = ref(null);
 const guardando = ref(false);
@@ -21,6 +22,28 @@ const error = ref('');
 const previewIcono = ref(null);
 
 const esEdicion = computed(() => !!props.cuadro);
+
+// Atributos reales del dataset del indicador, sólo como sugerencia (datalist): el
+// campo sigue siendo texto libre porque también se usan campos "virtuales" que sólo
+// existen en general_values y no son una columna real del dataset.
+const GEO_ATTRS = new Set(['the_geom', 'geometry', 'geom', 'wkb_geometry', 'shape']);
+const atributosDataset = ref([]);
+
+async function cargarAtributosDataset() {
+  atributosDataset.value = [];
+  try {
+    const indicador = await fetchIndicador(props.indicadorId);
+    const layerId = indicador?.layer;
+    if (!layerId) return;
+    const data = await fetchDatasetAttributes(layerId);
+    const attrs = data?.dataset?.attribute_set ?? data?.attribute_set ?? [];
+    atributosDataset.value = attrs
+      .map((a) => a.attribute)
+      .filter((name) => name && !GEO_ATTRS.has(name));
+  } catch {
+    atributosDataset.value = [];
+  }
+}
 
 const formulario = reactive({
   field: '',
@@ -120,6 +143,7 @@ watch(
   (m) => {
     if (m) {
       cargarDesdeCuadro();
+      cargarAtributosDataset();
       m.abrir();
     }
   },
@@ -145,9 +169,17 @@ watch(
                 id="cd-field"
                 v-model="formulario.field"
                 type="text"
+                list="cd-field-sugerencias"
                 placeholder="Ej: poblacion_total"
                 required
               />
+              <datalist id="cd-field-sugerencias">
+                <option v-for="attr in atributosDataset" :key="attr" :value="attr" />
+              </datalist>
+              <p v-if="atributosDataset.length" class="formulario-ayuda">
+                Sugerencias tomadas de las columnas reales del dataset del indicador. También puedes
+                escribir un campo que sólo exista en los valores generales del indicador.
+              </p>
             </div>
             <div class="campo">
               <label for="cd-name">Nombre personalizado <span class="requerido">*</span></label>

--- a/components/tableros/admin/FormularioIndicador.vue
+++ b/components/tableros/admin/FormularioIndicador.vue
@@ -16,15 +16,74 @@ const guardando = ref(false);
 const error = ref('');
 
 const PALETAS = [
-  { value: 'azules_3', label: 'Azules' },
-  { value: 'cafes', label: 'Cafés' },
-  { value: 'morados', label: 'Morados' },
-  { value: 'verdes_2', label: 'Verdes' },
-  { value: 'naranjas', label: 'Naranjas' },
-  { value: 'rosas', label: 'Rosas' },
-  { value: 'varios', label: 'Multicolor' },
-  { value: 'semaforo', label: 'Semáforo' },
-  { value: 'semaforo_3', label: 'Semáforo 3 tonos' },
+  {
+    group: 'Azules',
+    options: [
+      { value: 'azules', label: 'Azules' },
+      { value: 'azules_2', label: 'Azules 2' },
+      { value: 'azules_3', label: 'Azules 3' },
+      { value: 'azules_4', label: 'Azules 4' },
+      { value: 'azules_5', label: 'Azules 5' },
+    ],
+  },
+  {
+    group: 'Verdes',
+    options: [
+      { value: 'verdes', label: 'Verdes' },
+      { value: 'verdes_2', label: 'Verdes 2' },
+      { value: 'verdes_3', label: 'Verdes 3' },
+      { value: 'verdes_4', label: 'Verdes 4' },
+      { value: 'verdes_5', label: 'Verdes 5' },
+      { value: 'verdes_6', label: 'Verdes 6' },
+    ],
+  },
+  {
+    group: 'Cafés / naranjas',
+    options: [
+      { value: 'cafes', label: 'Cafés' },
+      { value: 'cafes_2', label: 'Cafés 2' },
+      { value: 'cafes_3', label: 'Cafés 3' },
+      { value: 'naranjas', label: 'Naranjas' },
+    ],
+  },
+  {
+    group: 'Morados / rosas',
+    options: [
+      { value: 'morados', label: 'Morados' },
+      { value: 'morados_2', label: 'Morados 2' },
+      { value: 'rosas', label: 'Rosas' },
+    ],
+  },
+  {
+    group: 'Divergentes',
+    options: [
+      { value: 'cafes_verdes', label: 'Café ↔ Verde' },
+      { value: 'naranja_azul', label: 'Naranja ↔ Azul' },
+      { value: 'rosa_verde', label: 'Rosa ↔ Verde' },
+    ],
+  },
+  {
+    group: 'Semáforo',
+    options: [
+      { value: 'semaforo', label: 'Semáforo' },
+      { value: 'semaforo_2', label: 'Semáforo 2' },
+      { value: 'semaforo_3', label: 'Semáforo 3 tonos' },
+      { value: 'semaforo_4', label: 'Semáforo 4 (invertido)' },
+      { value: 'semaforo_5', label: 'Semáforo 5 (intenso, invertido)' },
+      { value: 'semaforo_6', label: 'Semáforo 6 (3 colores)' },
+      { value: 'semaforo_7', label: 'Semáforo 7 (5 pasos)' },
+      { value: 'semaforo_8', label: 'Semáforo 8 (5 pasos)' },
+    ],
+  },
+  {
+    group: 'Otras',
+    options: [
+      { value: 'grises', label: 'Grises' },
+      { value: 'varios', label: 'Multicolor' },
+      { value: 'varios_2', label: 'Multicolor 2' },
+      { value: 'varios_3', label: 'Multicolor 3' },
+    ],
+  },
 ];
 
 const TIPOS_GRAFICA = [
@@ -62,11 +121,15 @@ const TIPOS_GRAFICA = [
 ];
 
 const METODOS = [
-  { value: 'quantile', label: 'Cuantiles' },
-  { value: 'jenks', label: 'Jenks (natural breaks)' },
-  { value: 'equal', label: 'Intervalos iguales' },
+  { value: 'quantil', label: 'Cuantiles' },
+  { value: 'naturalb', label: 'Jenks (natural breaks)' },
+  { value: 'sameintervals', label: 'Intervalos iguales' },
   { value: 'manual', label: 'Manual' },
 ];
+
+// Indicadores creados antes de este fix pueden tener guardados los valores en inglés
+// (quantile/jenks/equal) que el backend no reconoce; se normalizan al cargar.
+const METODOS_LEGADO = { quantile: 'quantil', jenks: 'naturalb', equal: 'sameintervals' };
 
 const formulario = reactive({
   name: '',
@@ -74,7 +137,7 @@ const formulario = reactive({
   plot_type: 'bar',
   colors: 'azules_3',
   reverse_colors: false,
-  category_method: 'quantile',
+  category_method: 'quantil',
   field_category: 5,
   use_single_field: true,
   show_general_values: false,
@@ -88,7 +151,8 @@ function cargarDesdeIndicador() {
   const rawColors = props.indicador.colors || 'azules_3';
   formulario.reverse_colors = rawColors.endsWith('_r');
   formulario.colors = formulario.reverse_colors ? rawColors.slice(0, -2) : rawColors;
-  formulario.category_method = props.indicador.category_method || 'quantile';
+  const rawMethod = props.indicador.category_method || 'quantil';
+  formulario.category_method = METODOS_LEGADO[rawMethod] || rawMethod;
   formulario.field_category = props.indicador.field_category ?? 5;
   formulario.use_single_field = props.indicador.use_single_field ?? true;
   formulario.show_general_values = props.indicador.show_general_values ?? false;
@@ -181,9 +245,11 @@ async function guardar() {
             <div class="campo">
               <label for="ind-paleta">Paleta de colores</label>
               <select id="ind-paleta" v-model="formulario.colors">
-                <option v-for="p in PALETAS" :key="p.value" :value="p.value">
-                  {{ p.label }}
-                </option>
+                <optgroup v-for="g in PALETAS" :key="g.group" :label="g.group">
+                  <option v-for="p in g.options" :key="p.value" :value="p.value">
+                    {{ p.label }}
+                  </option>
+                </optgroup>
               </select>
               <label class="check-inline m-t-1">
                 <input v-model="formulario.reverse_colors" type="checkbox" />

--- a/components/tableros/admin/ModalNuevoIndicador.vue
+++ b/components/tableros/admin/ModalNuevoIndicador.vue
@@ -24,12 +24,13 @@ const formulario = reactive({
   field_one: '',
   field_two: '',
   plot_type: 'bar',
-  category_method: 'quantile',
+  category_method: 'quantil',
   field_category: 5,
   colors: 'azules_3',
   reverse_colors: false,
   use_single_field: true,
   is_histogram: false,
+  show_general_values: true,
 });
 
 const CATEGORIAS_CAPAS = Object.entries(categoriesNamesInSpanish).map(([id, label]) => ({
@@ -208,6 +209,7 @@ async function guardar() {
       colors: colorsValue,
       use_single_field: formulario.use_single_field,
       is_histogram: formulario.is_histogram,
+      show_general_values: formulario.show_general_values,
       stack_order: 1,
     };
     const data = await crearIndicador(payload, userData.value?.accessToken);
@@ -447,9 +449,9 @@ onMounted(async () => {
               <div class="campo">
                 <label for="ind-method">Método</label>
                 <select id="ind-method" v-model="formulario.category_method">
-                  <option value="quantile">Cuantiles</option>
-                  <option value="jenks">Jenks (natural breaks)</option>
-                  <option value="equal">Intervalos iguales</option>
+                  <option value="quantil">Cuantiles</option>
+                  <option value="naturalb">Jenks (natural breaks)</option>
+                  <option value="sameintervals">Intervalos iguales</option>
                   <option value="manual">Manual</option>
                 </select>
               </div>
@@ -470,15 +472,53 @@ onMounted(async () => {
               <div class="campo">
                 <label for="ind-colors">Rampa de color</label>
                 <select id="ind-colors" v-model="formulario.colors">
-                  <option value="azules_3">Azules</option>
-                  <option value="cafes">Cafés</option>
-                  <option value="morados">Morados</option>
-                  <option value="verdes_2">Verdes</option>
-                  <option value="naranjas">Naranjas</option>
-                  <option value="rosas">Rosas</option>
-                  <option value="varios">Multicolor</option>
-                  <option value="semaforo">Semáforo</option>
-                  <option value="semaforo_3">Semáforo 3 tonos</option>
+                  <optgroup label="Azules">
+                    <option value="azules">Azules</option>
+                    <option value="azules_2">Azules 2</option>
+                    <option value="azules_3">Azules 3</option>
+                    <option value="azules_4">Azules 4</option>
+                    <option value="azules_5">Azules 5</option>
+                  </optgroup>
+                  <optgroup label="Verdes">
+                    <option value="verdes">Verdes</option>
+                    <option value="verdes_2">Verdes 2</option>
+                    <option value="verdes_3">Verdes 3</option>
+                    <option value="verdes_4">Verdes 4</option>
+                    <option value="verdes_5">Verdes 5</option>
+                    <option value="verdes_6">Verdes 6</option>
+                  </optgroup>
+                  <optgroup label="Cafés / naranjas">
+                    <option value="cafes">Cafés</option>
+                    <option value="cafes_2">Cafés 2</option>
+                    <option value="cafes_3">Cafés 3</option>
+                    <option value="naranjas">Naranjas</option>
+                  </optgroup>
+                  <optgroup label="Morados / rosas">
+                    <option value="morados">Morados</option>
+                    <option value="morados_2">Morados 2</option>
+                    <option value="rosas">Rosas</option>
+                  </optgroup>
+                  <optgroup label="Divergentes">
+                    <option value="cafes_verdes">Café ↔ Verde</option>
+                    <option value="naranja_azul">Naranja ↔ Azul</option>
+                    <option value="rosa_verde">Rosa ↔ Verde</option>
+                  </optgroup>
+                  <optgroup label="Semáforo">
+                    <option value="semaforo">Semáforo</option>
+                    <option value="semaforo_2">Semáforo 2</option>
+                    <option value="semaforo_3">Semáforo 3 tonos</option>
+                    <option value="semaforo_4">Semáforo 4 (invertido)</option>
+                    <option value="semaforo_5">Semáforo 5 (intenso, invertido)</option>
+                    <option value="semaforo_6">Semáforo 6 (3 colores)</option>
+                    <option value="semaforo_7">Semáforo 7 (5 pasos)</option>
+                    <option value="semaforo_8">Semáforo 8 (5 pasos)</option>
+                  </optgroup>
+                  <optgroup label="Otras">
+                    <option value="grises">Grises</option>
+                    <option value="varios">Multicolor</option>
+                    <option value="varios_2">Multicolor 2</option>
+                    <option value="varios_3">Multicolor 3</option>
+                  </optgroup>
                 </select>
                 <label class="check-inline m-t-1">
                   <input v-model="formulario.reverse_colors" type="checkbox" />
@@ -510,6 +550,12 @@ onMounted(async () => {
                 </select>
               </div>
             </div>
+
+            <label class="check-inline m-t-2">
+              <input v-model="formulario.show_general_values" type="checkbox" />
+              Mostrar valores generales (necesario para que los cuadros de datos del indicador
+              muestren un valor calculado)
+            </label>
           </div>
 
           <!-- ── Paso 3: Confirmar ── -->
@@ -553,6 +599,10 @@ onMounted(async () => {
               <div class="resumen-dl__fila">
                 <dt>Gráfica</dt>
                 <dd>{{ formulario.plot_type }}</dd>
+              </div>
+              <div class="resumen-dl__fila">
+                <dt>Valores generales</dt>
+                <dd>{{ formulario.show_general_values ? 'Sí' : 'No' }}</dd>
               </div>
             </dl>
             <p class="formulario-ayuda m-t-2">

--- a/components/tableros/admin/PickerIcono.vue
+++ b/components/tableros/admin/PickerIcono.vue
@@ -24,6 +24,8 @@ const GRUPOS = {
     'fas fa-poll-h',
     'fas fa-signal',
     'fas fa-percentage',
+    'fas fa-arrow-up',
+    'fas fa-arrow-down',
   ],
   Datos: [
     'fas fa-database',
@@ -54,6 +56,8 @@ const GRUPOS = {
     'fas fa-cloud',
     'fas fa-wind',
     'fas fa-fire',
+    'fas fa-fire-alt',
+    'fas fa-tint',
   ],
   Infraestructura: [
     'fas fa-road',
@@ -64,6 +68,9 @@ const GRUPOS = {
     'fas fa-truck',
     'fas fa-plug',
     'fas fa-wifi',
+    'fas fa-bolt',
+    'fas fa-oil-can',
+    'fas fa-solar-panel',
   ],
   Economía: [
     'fas fa-dollar-sign',

--- a/components/tableros/admin/TabBandaInstitucional.vue
+++ b/components/tableros/admin/TabBandaInstitucional.vue
@@ -177,7 +177,7 @@ watch(() => props.siteId, cargar, { immediate: true });
 
       <!-- Gestión de logos -->
       <div class="tab-banda__seccion">
-        <TablerosAdminSubidorLogosTopBar :top-bar-id="topBar.id" />
+        <TablerosAdminSubidorLogosTopBar :top-bar-id="props.siteId" />
       </div>
     </template>
   </div>

--- a/pages/geocontenidos/tableros/[sitio]/index.vue
+++ b/pages/geocontenidos/tableros/[sitio]/index.vue
@@ -125,7 +125,7 @@ const pestanias = computed(() => [
   { id: 'identidad', titulo: 'Identidad del sitio' },
   { id: 'banda', titulo: 'Banda institucional', deshabilitada: esNuevo.value },
   { id: 'estructura', titulo: 'Estructura', deshabilitada: esNuevo.value },
-  { id: 'datos', titulo: 'Datos estáticos', deshabilitada: esNuevo.value },
+  { id: 'datos', titulo: 'Cuadros de datos', deshabilitada: esNuevo.value },
 ]);
 
 cargarSitio();


### PR DESCRIPTION
## Resumen
- Alinea los valores de "Método" (cuantiles/jenks/intervalos) entre el asistente de nuevo indicador, el formulario de edición y el backend; normaliza los valores antiguos ya guardados.
- Activa por defecto "Mostrar valores generales" en el asistente de nuevo indicador, sin lo cual los cuadros de KPI nunca mostraban valor.
- Corrige el id de banda institucional usado para cargar su lista de logos.
- Evita que soltar un indicador sobre un subgrupo también dispare el handler del grupo y sobrescriba la asignación.
- Completa el selector de paletas de color con las variantes que soporta el backend, agrupadas por familia.
- Amplía el catálogo de íconos con los que ya usan datos reales.
- Expone el campo "Info" en la edición de grupo y en la creación/edición de subgrupo.
- Renombra la pestaña "Datos estáticos" a "Cuadros de datos".
- Sugiere en un datalist los atributos reales del dataset del indicador al capturar el campo de un cuadro de datos.

Depende de CentroGeo/sigic-geonode-wrapper#118 (corrige el cálculo de indicadores y las respuestas de guardado en el backend).

## Plan de pruebas
- [x] Editar un indicador existente conserva y guarda correctamente método, paleta y valores generales
- [x] Crear un indicador nuevo con el asistente muestra KPIs con valor real
- [x] La lista de logos de banda institucional muestra los logos existentes
- [x] Arrastrar un indicador a un subgrupo lo asigna correctamente, sin caer en el grupo completo